### PR TITLE
修复一些bug

### DIFF
--- a/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/MapScreen.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/MapScreen.kt
@@ -72,6 +72,7 @@ fun FullScreenMapPage(
 ) {
     val context = LocalContext.current
     var mapRef by remember { mutableStateOf<AppMapController?>(null) }
+    var showSavedLocations by remember { mutableStateOf(false) }
     var showMapTypeDialog by remember { mutableStateOf(false) }
     var showConfigDialog by remember { mutableStateOf(false) }
     var showSaveRouteDialog by remember { mutableStateOf(false) }
@@ -330,7 +331,7 @@ fun FullScreenMapPage(
 
                 AnimatedVisibility(visible = stage == RoutePlanStage.SELECTING && routePoints.isEmpty()) {
                     MapFab(
-                        icon = Icons.Rounded.Bookmarks,
+                        icon = Icons.Rounded.Route,
                         contentDescription = stringResource(R.string.route_library),
                         containerColor = MaterialTheme.colorScheme.surface,
                         contentColor = AccentBlue
@@ -340,14 +341,27 @@ fun FullScreenMapPage(
                 }
 
                 AnimatedVisibility(visible = (stage == RoutePlanStage.SELECTING && routePoints.isEmpty()) || stage == RoutePlanStage.IDLE) {
-                    MapFab(
-                        icon = Icons.Rounded.MyLocation,
-                        contentDescription = stringResource(R.string.locate_to_current),
-                        containerColor = MaterialTheme.colorScheme.surface,
-                        contentColor = AccentBlue
+                    Column (
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        viewModel.fetchCurrentLocation(context) { lLat, lLng ->
-                            mapRef?.animateCamera(lLat, lLng, 16f)
+                        MapFab(
+                            icon = Icons.Rounded.Bookmarks,
+                            contentDescription = stringResource(R.string.collection_list),
+                            containerColor = MaterialTheme.colorScheme.surface,
+                            contentColor = AccentBlue
+                        ) {
+                            showSavedLocations = true
+                        }
+
+                        MapFab(
+                            icon = Icons.Rounded.MyLocation,
+                            contentDescription = stringResource(R.string.locate_to_current),
+                            containerColor = MaterialTheme.colorScheme.surface,
+                            contentColor = AccentBlue
+                        ) {
+                            viewModel.fetchCurrentLocation(context) { lLat, lLng ->
+                                mapRef?.animateCamera(lLat, lLng, 16f)
+                            }
                         }
                     }
                 }
@@ -505,6 +519,19 @@ fun FullScreenMapPage(
                 }
             }
         }
+    }
+
+    // 地点收藏列表
+    if (showSavedLocations) {
+        SavedLocationsDialog(
+            savedLocations = uiState.savedLocations,
+            onDismiss = { showSavedLocations = false },
+            onSelect = { loc ->
+                showSavedLocations = false
+                mapRef?.animateCamera(loc.lat, loc.lng)
+            },
+            onDelete = { loc -> viewModel.removeSavedLocation(loc) }
+        )
     }
 
     if (showSavedRoutesDialog) {

--- a/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/MapScreen.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/MapScreen.kt
@@ -339,14 +339,16 @@ fun FullScreenMapPage(
                     }
                 }
 
-                MapFab(
-                    icon = Icons.Rounded.MyLocation,
-                    contentDescription = stringResource(R.string.locate_to_current),
-                    containerColor = MaterialTheme.colorScheme.surface,
-                    contentColor = AccentBlue
-                ) {
-                    viewModel.fetchCurrentLocation(context) { lLat, lLng ->
-                        mapRef?.animateCamera(lLat, lLng, 16f)
+                AnimatedVisibility(visible = (stage == RoutePlanStage.SELECTING && routePoints.isEmpty()) || stage == RoutePlanStage.IDLE) {
+                    MapFab(
+                        icon = Icons.Rounded.MyLocation,
+                        contentDescription = stringResource(R.string.locate_to_current),
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        contentColor = AccentBlue
+                    ) {
+                        viewModel.fetchCurrentLocation(context) { lLat, lLng ->
+                            mapRef?.animateCamera(lLat, lLng, 16f)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/MapScreen.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/MapScreen.kt
@@ -328,7 +328,7 @@ fun FullScreenMapPage(
                     showMapTypeDialog = true
                 }
 
-                AnimatedVisibility(visible = stage == RoutePlanStage.SELECTING || stage == RoutePlanStage.READY || stage == RoutePlanStage.IDLE) {
+                AnimatedVisibility(visible = stage == RoutePlanStage.SELECTING && routePoints.isEmpty()) {
                     MapFab(
                         icon = Icons.Rounded.Bookmarks,
                         contentDescription = stringResource(R.string.route_library),


### PR DESCRIPTION
### fix: 修复路线库未正确隐藏的问题
- 现在路线库仅在正在选点（路点为0）时显示。

### fix: 优化规划路线页面中定位按钮显示逻辑
- 在正在选点模式（路点大于0）、结束选点、路线模拟运行中时**隐藏**定位到当前位置按钮

### feat: 全屏选点页面与规划路线页面新增收藏列表按钮
- 路线库图标由 Icons.Rounded.Bookmarks 更换为 Icons.Rounded.Route
- 全屏选点与规划路线页面增加收藏列表按钮，隐藏逻辑与定位按钮一致