### PR TITLE
Allow live fixed-location updates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,5 +126,8 @@ dependencies {
     implementation(libs.room.ktx)
     ksp(libs.room.compiler)
 
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.json:json:20240303")
+
     debugImplementation(libs.androidx.ui.tooling)
 }

--- a/app/src/main/java/com/suseoaa/locationspoofer/data/model/SavedLocation.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/data/model/SavedLocation.kt
@@ -5,5 +5,6 @@ data class SavedLocation(
     val lat: Double, 
     val lng: Double,
     val wifiJson: String = "[]",
-    val cellJson: String = "[]"
+    val cellJson: String = "[]",
+    val bluetoothJson: String = "[]"
 )

--- a/app/src/main/java/com/suseoaa/locationspoofer/data/repository/LocationRepository.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/data/repository/LocationRepository.kt
@@ -39,7 +39,16 @@ class LocationRepository(
         mockCell: Boolean = true,
         mockBluetooth: Boolean = true,
         enableJitter: Boolean = true
-    ) {
+    ): Boolean {
+        val alt = settingsManager.altitude.toDoubleOrNull() ?: 0.0
+        val satCount = settingsManager.satelliteCount.toIntOrNull() ?: 20
+        val configWritten = configManager.saveConfig(
+            lat, lng, true, simMode, simBearing, startTime, routePoints, isRouteMode,
+            wifiJson, appCoordinateSystems, cellJson, bluetoothJson,
+            mockWifi, mockCell, mockBluetooth, enableJitter, alt, satCount
+        )
+        if (!configWritten) return false
+
         SpooferProvider.isActive = true
         SpooferProvider.latitude = lat
         SpooferProvider.longitude = lng
@@ -52,10 +61,6 @@ class LocationRepository(
         SpooferProvider.routeJson = routePointsToJson(routePoints)
         SpooferProvider.isRouteMode = isRouteMode
         SpooferProvider.enableJitter = enableJitter
-
-        val alt = settingsManager.altitude.toDoubleOrNull() ?: 0.0
-        val satCount = settingsManager.satelliteCount.toIntOrNull() ?: 20
-        configManager.saveConfig(lat, lng, true, simMode, simBearing, startTime, routePoints, isRouteMode, SpooferProvider.wifiJson, appCoordinateSystems, SpooferProvider.cellJson, SpooferProvider.bluetoothJson, mockWifi, mockCell, mockBluetooth, enableJitter, alt, satCount)
         rootManager.grantMockLocation()
 
         context.startForegroundService(
@@ -65,20 +70,22 @@ class LocationRepository(
                 putExtra(SpoofingService.EXTRA_LNG, lng)
             }
         )
+        return true
     }
 
-    suspend fun stopSpoofing(context: Context) {
+    suspend fun stopSpoofing(context: Context): Boolean {
+        val configWritten = configManager.saveConfig(0.0, 0.0, false)
         SpooferProvider.isActive = false
         SpooferProvider.wifiJson = "[]"
         SpooferProvider.cellJson = "[]"
         SpooferProvider.bluetoothJson = "[]"
         SpooferProvider.routeJson = "[]"
         SpooferProvider.isRouteMode = false
-        configManager.saveConfig(0.0, 0.0, false)
         context.startService(Intent(context, SpoofingService::class.java).apply {
             action = SpoofingService.ACTION_STOP
         })
         rootManager.revokeMockLocation()
+        return configWritten
     }
 
     suspend fun updateConfig(
@@ -97,7 +104,16 @@ class LocationRepository(
         mockCell: Boolean = true,
         mockBluetooth: Boolean = true,
         enableJitter: Boolean = true
-    ) {
+    ): Boolean {
+        val alt = settingsManager.altitude.toDoubleOrNull() ?: 0.0
+        val satCount = settingsManager.satelliteCount.toIntOrNull() ?: 20
+        val configWritten = configManager.saveConfig(
+            lat, lng, true, simMode, simBearing, startTime, routePoints, isRouteMode,
+            wifiJson, appCoordinateSystems, cellJson, bluetoothJson,
+            mockWifi, mockCell, mockBluetooth, enableJitter, alt, satCount
+        )
+        if (!configWritten) return false
+
         SpooferProvider.latitude = lat
         SpooferProvider.longitude = lng
         SpooferProvider.startTimestamp = startTime
@@ -109,15 +125,12 @@ class LocationRepository(
         SpooferProvider.cellJson = cellJson
         SpooferProvider.bluetoothJson = bluetoothJson
         SpooferProvider.enableJitter = enableJitter
-        val alt = settingsManager.altitude.toDoubleOrNull() ?: 0.0
-        val satCount = settingsManager.satelliteCount.toIntOrNull() ?: 20
-        configManager.saveConfig(lat, lng, true, simMode, simBearing, startTime, routePoints, isRouteMode, SpooferProvider.wifiJson, appCoordinateSystems, SpooferProvider.cellJson, SpooferProvider.bluetoothJson, mockWifi, mockCell, mockBluetooth, enableJitter, alt, satCount)
+        return true
     }
 
-    suspend fun updateWifiJson(wifiJson: String, appCoordinateSystems: Map<String, String>) {
-        SpooferProvider.wifiJson = wifiJson
+    suspend fun updateWifiJson(wifiJson: String, appCoordinateSystems: Map<String, String>): Boolean {
         // 同步写入配置文件,确保Xposed端能读取到WiFi数据
-        configManager.saveConfig(
+        val configWritten = configManager.saveConfig(
             SpooferProvider.latitude,
             SpooferProvider.longitude,
             SpooferProvider.isActive,
@@ -131,6 +144,10 @@ class LocationRepository(
             altitude = settingsManager.altitude.toDoubleOrNull() ?: 0.0,
             satelliteCount = settingsManager.satelliteCount.toIntOrNull() ?: 20
         )
+        if (configWritten) {
+            SpooferProvider.wifiJson = wifiJson
+        }
+        return configWritten
     }
 
     private fun routePointsToJson(points: List<RoutePoint>): String {

--- a/app/src/main/java/com/suseoaa/locationspoofer/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/data/repository/SettingsRepository.kt
@@ -86,9 +86,11 @@ class SettingsRepository(private val settingsManager: SettingsManager) {
         get() = settingsManager.isSpoofingActive
         set(value) { settingsManager.isSpoofingActive = value }
 
-    var isRouteSpoofingActive: Boolean
+    val isRouteSpoofingActive: Boolean
         get() = settingsManager.isRouteSpoofingActive
-        set(value) { settingsManager.isRouteSpoofingActive = value }
+
+    fun setSpoofingSession(active: Boolean, route: Boolean) =
+        settingsManager.setSpoofingSession(active, route)
 
     var lastSpoofedLat: String
         get() = settingsManager.lastSpoofedLat

--- a/app/src/main/java/com/suseoaa/locationspoofer/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/data/repository/SettingsRepository.kt
@@ -86,6 +86,10 @@ class SettingsRepository(private val settingsManager: SettingsManager) {
         get() = settingsManager.isSpoofingActive
         set(value) { settingsManager.isSpoofingActive = value }
 
+    var isRouteSpoofingActive: Boolean
+        get() = settingsManager.isRouteSpoofingActive
+        set(value) { settingsManager.isRouteSpoofingActive = value }
+
     var lastSpoofedLat: String
         get() = settingsManager.lastSpoofedLat
         set(value) { settingsManager.lastSpoofedLat = value }

--- a/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/ManageDataScreen.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/ManageDataScreen.kt
@@ -180,8 +180,7 @@ fun ManageDataScreen(
                                 }
                             },
                             onClick = {
-                                viewModel.updateLatitude(String.format(Locale.US, "%.6f", item.location.lat))
-                                viewModel.updateLongitude(String.format(Locale.US, "%.6f", item.location.lng))
+                                viewModel.selectFixedLocation(item.location.lat, item.location.lng)
                                 mapController?.animateCamera(item.location.lat, item.location.lng, 17f)
                                 // Optionally close the screen to return to SpoofingScreen?
                                 // onClose() // Let's keep it open so they can see the map move

--- a/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/MapScreen.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/MapScreen.kt
@@ -528,7 +528,12 @@ fun FullScreenMapPage(
             onDismiss = { showSavedLocations = false },
             onSelect = { loc ->
                 showSavedLocations = false
-                mapRef?.animateCamera(loc.lat, loc.lng)
+                if (stage == RoutePlanStage.IDLE) {
+                    viewModel.loadSavedLocation(loc)
+                    onClose()
+                } else {
+                    mapRef?.animateCamera(loc.lat, loc.lng)
+                }
             },
             onDelete = { loc -> viewModel.removeSavedLocation(loc) }
         )

--- a/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/SpoofingScreen.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/SpoofingScreen.kt
@@ -327,8 +327,7 @@ fun SpoofingScreen(
                                 .clickable {
                                     val pLat = poi.lat
                                     val pLng = poi.lng
-                                    viewModel.updateLatitude(String.format("%.6f", pLat))
-                                    viewModel.updateLongitude(String.format("%.6f", pLng))
+                                    viewModel.selectFixedLocation(pLat, pLng)
                                     smallMapRef?.animateCamera(pLat, pLng, 16f)
                                     showSearchResults = false
                                     searchQuery = poi.title
@@ -752,8 +751,14 @@ fun SpoofingScreen(
             isDark = isDark,
             onDismiss = { showCustomCoordDialog = false },
             onConfirm = { lat, lng ->
-                viewModel.updateLatitude(lat)
-                viewModel.updateLongitude(lng)
+                val parsedLat = lat.toDoubleOrNull()
+                val parsedLng = lng.toDoubleOrNull()
+                if (parsedLat != null && parsedLng != null) {
+                    viewModel.selectFixedLocation(parsedLat, parsedLng)
+                } else {
+                    viewModel.updateLatitude(lat)
+                    viewModel.updateLongitude(lng)
+                }
                 showCustomCoordDialog = false
             }
         )

--- a/app/src/main/java/com/suseoaa/locationspoofer/utils/ConfigManager.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/utils/ConfigManager.kt
@@ -79,23 +79,60 @@ class ConfigManager(private val rootManager: RootManager) {
             )
 
             // 使用 quoted heredoc 写入，避免 JSON 中的引号、美元符号等被 shell 解析。
-            // 每个目标都先写同目录临时文件再 rename，避免 hook 轮询线程读到半截 JSON。
+            // 两个目标都先完成 staging；发布任一副本后若后续步骤失败，则恢复旧副本，
+            // 避免 app hook 与 system hook 观察到一次失败写入的不同状态。
             val jsonText = json.toString()
             val command = """
             set -e
+            local_target=/data/local/tmp/locationspoofer_config.json
+            system_target=/data/system/locationspoofer_config.json
             local_tmp=/data/local/tmp/.locationspoofer_config.json.tmp.$$
             system_tmp=/data/system/.locationspoofer_config.json.tmp.$$
-            cleanup() {
-              rm -f "${'$'}local_tmp" "${'$'}system_tmp"
+            local_backup=/data/local/tmp/.locationspoofer_config.json.backup.$$
+            system_backup=/data/system/.locationspoofer_config.json.backup.$$
+            had_local=0
+            had_system=0
+            published_local=0
+            published_system=0
+            committed=0
+            finish() {
+              status=${'$'}?
+              trap - EXIT HUP INT TERM
+              set +e
+              if [ "${'$'}committed" -ne 1 ]; then
+                if [ "${'$'}published_local" -eq 1 ]; then
+                  if [ "${'$'}had_local" -eq 1 ]; then
+                    mv -f "${'$'}local_backup" "${'$'}local_target"
+                    chmod 666 "${'$'}local_target"
+                    chcon u:object_r:shell_data_file:s0 "${'$'}local_target" 2>/dev/null || true
+                  else
+                    rm -f "${'$'}local_target"
+                  fi
+                fi
+                if [ "${'$'}published_system" -eq 1 ]; then
+                  if [ "${'$'}had_system" -eq 1 ]; then
+                    mv -f "${'$'}system_backup" "${'$'}system_target"
+                    chown system:system "${'$'}system_target" 2>/dev/null || true
+                    chmod 644 "${'$'}system_target"
+                    chcon u:object_r:system_data_file:s0 "${'$'}system_target" 2>/dev/null || true
+                  else
+                    rm -f "${'$'}system_target"
+                  fi
+                fi
+              fi
+              rm -f "${'$'}local_tmp" "${'$'}system_tmp" "${'$'}local_backup" "${'$'}system_backup"
+              exit "${'$'}status"
             }
-            trap cleanup EXIT HUP INT TERM
+            trap finish EXIT
+            trap 'exit 129' HUP
+            trap 'exit 130' INT
+            trap 'exit 143' TERM
 
             cat > "${'$'}local_tmp" <<'LOCATIONSPOOFER_JSON'
             $jsonText
             LOCATIONSPOOFER_JSON
             chmod 666 "${'$'}local_tmp"
             chcon u:object_r:shell_data_file:s0 "${'$'}local_tmp" 2>/dev/null || true
-            mv -f "${'$'}local_tmp" /data/local/tmp/locationspoofer_config.json
 
             cat > "${'$'}system_tmp" <<'LOCATIONSPOOFER_JSON_SYSTEM'
             $jsonText
@@ -103,10 +140,21 @@ class ConfigManager(private val rootManager: RootManager) {
             chown system:system "${'$'}system_tmp" 2>/dev/null || true
             chmod 644 "${'$'}system_tmp"
             chcon u:object_r:system_data_file:s0 "${'$'}system_tmp" 2>/dev/null || true
-            mv -f "${'$'}system_tmp" /data/system/locationspoofer_config.json
 
-            trap - EXIT HUP INT TERM
-            cleanup
+            if [ -e "${'$'}local_target" ]; then
+              cp "${'$'}local_target" "${'$'}local_backup"
+              had_local=1
+            fi
+            if [ -e "${'$'}system_target" ]; then
+              cp "${'$'}system_target" "${'$'}system_backup"
+              had_system=1
+            fi
+
+            mv -f "${'$'}local_tmp" "${'$'}local_target"
+            published_local=1
+            mv -f "${'$'}system_tmp" "${'$'}system_target"
+            published_system=1
+            committed=1
             """.trimIndent()
 
         val result = rootManager.executeCommand(command)

--- a/app/src/main/java/com/suseoaa/locationspoofer/utils/ConfigManager.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/utils/ConfigManager.kt
@@ -2,11 +2,14 @@ package com.suseoaa.locationspoofer.utils
 
 import com.suseoaa.locationspoofer.data.model.RoutePoint
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 
 class ConfigManager(private val rootManager: RootManager) {
+    private val saveMutex = Mutex()
 
     suspend fun saveConfig(
         lat: Double,
@@ -27,74 +30,98 @@ class ConfigManager(private val rootManager: RootManager) {
         enableJitter: Boolean = true,
         altitude: Double = 0.0,
         satelliteCount: Int = 20
-    ) = withContext(Dispatchers.IO) {
-        val routeArray = JSONArray()
-        routePoints.forEach { p ->
-            val obj = JSONObject()
-            obj.put("lat", p.lat)
-            obj.put("lng", p.lng)
-            routeArray.put(obj)
-        }
-
-        val json = JSONObject().apply {
-            put("lat", lat)
-            put("lng", lng)
-            put("active", active)
-            put("sim_mode", simMode)
-            put("sim_bearing", simBearing.toDouble())
-            put("start_timestamp", startTimestamp)
-            put("route_points", routeArray)
-            put("is_route_mode", isRouteMode)
-            val wifiObj = try {
-                JSONObject(wifiJson)
-            } catch (e: Exception) {
-                JSONObject().apply {
-                    put("isConnected", false)
-                    put("connectedWifi", JSONObject.NULL)
-                    put("nearbyWifi", JSONArray())
-                }
+    ) = saveMutex.withLock {
+        withContext(Dispatchers.IO) {
+            val routeArray = JSONArray()
+            routePoints.forEach { p ->
+                val obj = JSONObject()
+                obj.put("lat", p.lat)
+                obj.put("lng", p.lng)
+                routeArray.put(obj)
             }
-            put("wifi_json", wifiObj)
-            put("cell_json", JSONArray(cellJson))
-            put("bluetooth_json", JSONArray(bluetoothJson))
-            put("mock_wifi", mockWifi)
-            put("mock_cell", mockCell)
-            put("mock_bluetooth", mockBluetooth)
-            put("enable_jitter", enableJitter)
-            put("altitude", altitude)
-            put("satellite_count", satelliteCount)
-            
-            val coordSysObj = JSONObject()
-            appCoordinateSystems.forEach { (pkg, sys) -> coordSysObj.put(pkg, sys) }
-            put("app_coordinate_systems", coordSysObj)
-        }
-        val cellCount = json.optJSONArray("cell_json")?.length() ?: 0
-        android.util.Log.d(
-            "OpenCellID",
-            "saveConfig: active=$active mockCell=$mockCell lat=$lat lng=$lng cellJsonCount=$cellCount"
-        )
 
-        // 使用 quoted heredoc 写入，避免 JSON 中的引号、美元符号等被 shell 解析。
-        val jsonText = json.toString()
-        val command = """
-            cat > /data/local/tmp/locationspoofer_config.json <<'LOCATIONSPOOFER_JSON'
+            val json = JSONObject().apply {
+                put("lat", lat)
+                put("lng", lng)
+                put("active", active)
+                put("sim_mode", simMode)
+                put("sim_bearing", simBearing.toDouble())
+                put("start_timestamp", startTimestamp)
+                put("route_points", routeArray)
+                put("is_route_mode", isRouteMode)
+                val wifiObj = try {
+                    JSONObject(wifiJson)
+                } catch (e: Exception) {
+                    JSONObject().apply {
+                        put("isConnected", false)
+                        put("connectedWifi", JSONObject.NULL)
+                        put("nearbyWifi", JSONArray())
+                    }
+                }
+                put("wifi_json", wifiObj)
+                put("cell_json", JSONArray(cellJson))
+                put("bluetooth_json", JSONArray(bluetoothJson))
+                put("mock_wifi", mockWifi)
+                put("mock_cell", mockCell)
+                put("mock_bluetooth", mockBluetooth)
+                put("enable_jitter", enableJitter)
+                put("altitude", altitude)
+                put("satellite_count", satelliteCount)
+
+                val coordSysObj = JSONObject()
+                appCoordinateSystems.forEach { (pkg, sys) -> coordSysObj.put(pkg, sys) }
+                put("app_coordinate_systems", coordSysObj)
+            }
+            val cellCount = json.optJSONArray("cell_json")?.length() ?: 0
+            android.util.Log.d(
+                "OpenCellID",
+                "saveConfig: active=$active mockCell=$mockCell lat=$lat lng=$lng cellJsonCount=$cellCount"
+            )
+
+            // 使用 quoted heredoc 写入，避免 JSON 中的引号、美元符号等被 shell 解析。
+            // 每个目标都先写同目录临时文件再 rename，避免 hook 轮询线程读到半截 JSON。
+            val jsonText = json.toString()
+            val command = """
+            set -e
+            local_tmp=/data/local/tmp/.locationspoofer_config.json.tmp.$$
+            system_tmp=/data/system/.locationspoofer_config.json.tmp.$$
+            cleanup() {
+              rm -f "${'$'}local_tmp" "${'$'}system_tmp"
+            }
+            trap cleanup EXIT HUP INT TERM
+
+            cat > "${'$'}local_tmp" <<'LOCATIONSPOOFER_JSON'
             $jsonText
             LOCATIONSPOOFER_JSON
-            chmod 666 /data/local/tmp/locationspoofer_config.json
-            chcon u:object_r:shell_data_file:s0 /data/local/tmp/locationspoofer_config.json 2>/dev/null || true
+            chmod 666 "${'$'}local_tmp"
+            chcon u:object_r:shell_data_file:s0 "${'$'}local_tmp" 2>/dev/null || true
+            mv -f "${'$'}local_tmp" /data/local/tmp/locationspoofer_config.json
 
-            cat > /data/system/locationspoofer_config.json <<'LOCATIONSPOOFER_JSON_SYSTEM'
+            cat > "${'$'}system_tmp" <<'LOCATIONSPOOFER_JSON_SYSTEM'
             $jsonText
             LOCATIONSPOOFER_JSON_SYSTEM
-            chown system:system /data/system/locationspoofer_config.json 2>/dev/null || true
-            chmod 644 /data/system/locationspoofer_config.json
-            chcon u:object_r:system_data_file:s0 /data/system/locationspoofer_config.json 2>/dev/null || true
-        """.trimIndent()
+            chown system:system "${'$'}system_tmp" 2>/dev/null || true
+            chmod 644 "${'$'}system_tmp"
+            chcon u:object_r:system_data_file:s0 "${'$'}system_tmp" 2>/dev/null || true
+            mv -f "${'$'}system_tmp" /data/system/locationspoofer_config.json
+
+            trap - EXIT HUP INT TERM
+            cleanup
+            """.trimIndent()
 
         val result = rootManager.executeCommand(command)
+        if (result.startsWith("ERROR")) {
+            android.util.Log.e(
+                "OpenCellID",
+                "saveConfig: failed to write config copies: ${result.take(500)}"
+            )
+            return@withContext false
+        }
         android.util.Log.d(
-            "OpenCellID",
-            "saveConfig: wrote config copies to /data/local/tmp and /data/system, result=${result.take(200)}"
-        )
+                "OpenCellID",
+                "saveConfig: wrote config copies to /data/local/tmp and /data/system, result=${result.take(200)}"
+            )
+            true
+        }
     }
 }

--- a/app/src/main/java/com/suseoaa/locationspoofer/utils/ConfigWriteGate.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/utils/ConfigWriteGate.kt
@@ -1,0 +1,27 @@
+package com.suseoaa.locationspoofer.utils
+
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/** Serializes config writes and rejects work from an obsolete spoofing session. */
+class ConfigWriteGate {
+    private val mutex = Mutex()
+    private val generation = AtomicLong(0)
+
+    fun currentGeneration(): Long = generation.get()
+
+    fun beginNewGeneration(): Long = generation.incrementAndGet()
+
+    suspend fun runIfCurrent(
+        expectedGeneration: Long,
+        block: suspend () -> Unit
+    ): Boolean = mutex.withLock {
+        if (expectedGeneration != generation.get()) {
+            false
+        } else {
+            block()
+            expectedGeneration == generation.get()
+        }
+    }
+}

--- a/app/src/main/java/com/suseoaa/locationspoofer/utils/EnvironmentPayloads.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/utils/EnvironmentPayloads.kt
@@ -1,0 +1,49 @@
+package com.suseoaa.locationspoofer.utils
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+data class WifiPayloadInfo(
+    val hasData: Boolean,
+    val nearbyCount: Int
+)
+
+data class EnvironmentJsonPayload(
+    val wifiJson: String,
+    val cellJson: String,
+    val bluetoothJson: String
+)
+
+object EnvironmentPayloads {
+    fun merge(
+        localWifiJson: String,
+        localCellJson: String,
+        localBluetoothJson: String,
+        wifiJsonOverride: String?,
+        cellJsonOverride: String?,
+        bluetoothJsonOverride: String?
+    ): EnvironmentJsonPayload = EnvironmentJsonPayload(
+        wifiJson = wifiJsonOverride ?: localWifiJson,
+        cellJson = cellJsonOverride ?: localCellJson,
+        bluetoothJson = bluetoothJsonOverride ?: localBluetoothJson
+    )
+
+    fun inspectWifi(json: String): WifiPayloadInfo {
+        return try {
+            val obj = JSONObject(json)
+            val nearbyCount = obj.optJSONArray("nearbyWifi")?.length() ?: 0
+            val hasConnectedWifi = obj.optJSONObject("connectedWifi") != null
+            WifiPayloadInfo(hasConnectedWifi || nearbyCount > 0, nearbyCount)
+        } catch (_: Exception) {
+            WifiPayloadInfo(hasData = false, nearbyCount = 0)
+        }
+    }
+
+    fun hasArrayItems(json: String): Boolean {
+        return try {
+            JSONArray(json).length() > 0
+        } catch (_: Exception) {
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/suseoaa/locationspoofer/utils/EnvironmentPayloads.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/utils/EnvironmentPayloads.kt
@@ -15,6 +15,12 @@ data class EnvironmentJsonPayload(
 )
 
 object EnvironmentPayloads {
+    fun usableWifiOverride(json: String?): String? =
+        json?.takeIf { inspectWifi(it).hasData }
+
+    fun usableArrayOverride(json: String?): String? =
+        json?.takeIf { hasArrayItems(it) }
+
     fun merge(
         localWifiJson: String,
         localCellJson: String,

--- a/app/src/main/java/com/suseoaa/locationspoofer/utils/RootManager.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/utils/RootManager.kt
@@ -2,8 +2,14 @@ package com.suseoaa.locationspoofer.utils
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.BufferedReader
-import java.io.InputStreamReader
+
+internal fun formatShellCommandResult(exitCode: Int, output: String): String {
+    return if (exitCode == 0) {
+        output.ifEmpty { "SUCCESS" }
+    } else {
+        "ERROR(exit=$exitCode): ${output.take(500)}"
+    }
+}
 
 class RootManager {
 
@@ -14,24 +20,25 @@ class RootManager {
     suspend fun grantMockLocation(): Boolean = withContext(Dispatchers.IO) {
         val result =
             executeCommand("appops set com.suseoaa.locationspoofer android:mock_location allow")
-        result != "ERROR"
+        !result.startsWith("ERROR")
     }
 
     suspend fun revokeMockLocation(): Boolean = withContext(Dispatchers.IO) {
         val result =
             executeCommand("appops set com.suseoaa.locationspoofer android:mock_location deny")
-        result != "ERROR"
+        !result.startsWith("ERROR")
     }
 
     fun executeCommand(command: String): String {
         return try {
-            val process = Runtime.getRuntime().exec(arrayOf("su", "-c", command))
-            val reader = BufferedReader(InputStreamReader(process.inputStream))
-            val output = reader.readText()
-            process.waitFor()
-            output.ifEmpty { "SUCCESS" }
+            val process = ProcessBuilder("su", "-c", command)
+                .redirectErrorStream(true)
+                .start()
+            val output = process.inputStream.bufferedReader().use { it.readText() }
+            val exitCode = process.waitFor()
+            formatShellCommandResult(exitCode, output)
         } catch (e: Exception) {
-            "ERROR"
+            "ERROR: ${e.message.orEmpty()}"
         }
     }
 }

--- a/app/src/main/java/com/suseoaa/locationspoofer/utils/SavedLocationJsonCodec.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/utils/SavedLocationJsonCodec.kt
@@ -1,0 +1,39 @@
+package com.suseoaa.locationspoofer.utils
+
+import com.suseoaa.locationspoofer.data.model.SavedLocation
+import org.json.JSONArray
+import org.json.JSONObject
+
+object SavedLocationJsonCodec {
+    fun decode(json: String): List<SavedLocation> {
+        val result = mutableListOf<SavedLocation>()
+        val array = JSONArray(json)
+        for (index in 0 until array.length()) {
+            val obj = array.getJSONObject(index)
+            result += SavedLocation(
+                name = obj.getString("name"),
+                lat = obj.getDouble("lat"),
+                lng = obj.getDouble("lng"),
+                wifiJson = obj.optString("wifiJson", "[]"),
+                cellJson = obj.optString("cellJson", "[]"),
+                bluetoothJson = obj.optString("bluetoothJson", "[]")
+            )
+        }
+        return result
+    }
+
+    fun encode(locations: List<SavedLocation>): String {
+        val array = JSONArray()
+        locations.forEach { location ->
+            array.put(JSONObject().apply {
+                put("name", location.name)
+                put("lat", location.lat)
+                put("lng", location.lng)
+                put("wifiJson", location.wifiJson)
+                put("cellJson", location.cellJson)
+                put("bluetoothJson", location.bluetoothJson)
+            })
+        }
+        return array.toString()
+    }
+}

--- a/app/src/main/java/com/suseoaa/locationspoofer/utils/SettingsManager.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/utils/SettingsManager.kt
@@ -59,6 +59,10 @@ class SettingsManager(context: Context) {
         get() = prefs.getBoolean("is_spoofing_active", false)
         set(value) = prefs.edit().putBoolean("is_spoofing_active", value).apply()
 
+    var isRouteSpoofingActive: Boolean
+        get() = prefs.getBoolean("is_route_spoofing_active", false)
+        set(value) = prefs.edit().putBoolean("is_route_spoofing_active", value).apply()
+
     var lastSpoofedLat: String
         get() = prefs.getString("last_spoofed_lat", "0") ?: "0"
         set(value) = prefs.edit().putString("last_spoofed_lat", value).apply()

--- a/app/src/main/java/com/suseoaa/locationspoofer/utils/SettingsManager.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/utils/SettingsManager.kt
@@ -59,9 +59,15 @@ class SettingsManager(context: Context) {
         get() = prefs.getBoolean("is_spoofing_active", false)
         set(value) = prefs.edit().putBoolean("is_spoofing_active", value).apply()
 
-    var isRouteSpoofingActive: Boolean
+    val isRouteSpoofingActive: Boolean
         get() = prefs.getBoolean("is_route_spoofing_active", false)
-        set(value) = prefs.edit().putBoolean("is_route_spoofing_active", value).apply()
+
+    fun setSpoofingSession(active: Boolean, route: Boolean) {
+        prefs.edit()
+            .putBoolean("is_spoofing_active", active)
+            .putBoolean("is_route_spoofing_active", route)
+            .apply()
+    }
 
     var lastSpoofedLat: String
         get() = prefs.getString("last_spoofed_lat", "0") ?: "0"

--- a/app/src/main/java/com/suseoaa/locationspoofer/utils/SettingsManager.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/utils/SettingsManager.kt
@@ -93,17 +93,12 @@ class SettingsManager(context: Context) {
 
     fun getSavedLocations(): List<SavedLocation> {
         val jsonString = prefs.getString("saved_locations", "[]") ?: "[]"
-        val list = mutableListOf<SavedLocation>()
-        try {
-            val jsonArray = JSONArray(jsonString)
-            for (i in 0 until jsonArray.length()) {
-                val obj = jsonArray.getJSONObject(i)
-                list.add(SavedLocation(obj.getString("name"), obj.getDouble("lat"), obj.getDouble("lng")))
-            }
+        return try {
+            SavedLocationJsonCodec.decode(jsonString)
         } catch (e: Exception) {
             e.printStackTrace()
+            emptyList()
         }
-        return list
     }
 
     fun addSavedLocation(location: SavedLocation) {
@@ -119,15 +114,7 @@ class SettingsManager(context: Context) {
     }
 
     private fun saveLocationList(list: List<SavedLocation>) {
-        val jsonArray = JSONArray()
-        list.forEach {
-            val obj = JSONObject()
-            obj.put("name", it.name)
-            obj.put("lat", it.lat)
-            obj.put("lng", it.lng)
-            jsonArray.put(obj)
-        }
-        prefs.edit().putString("saved_locations", jsonArray.toString()).apply()
+        prefs.edit().putString("saved_locations", SavedLocationJsonCodec.encode(list)).apply()
     }
 
     fun getSavedRoutes(): List<SavedRoute> {

--- a/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
+import java.util.Locale
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -76,6 +77,7 @@ class MainViewModel(
     private var locationSyncJob: Job? = null
     private var autoRouteJob: Job? = null
     private var continuousScanJob: Job? = null
+    private var liveFixedLocationJob: Job? = null
 
     init {
         initialize()
@@ -484,6 +486,10 @@ class MainViewModel(
             _uiState.update { it.copy(latitudeInput = value, showCoordinateError = false) }
             evaluateMockCapabilities()
         }
+    }
+
+    fun selectFixedLocation(lat: Double, lng: Double) {
+        updateSelectedLocation(lat, lng)
     }
 
     private fun isValidCoord(value: String): Boolean {
@@ -912,6 +918,8 @@ class MainViewModel(
 
     fun stopSpoofing() {
         settingsRepository.isSpoofingActive = false
+        liveFixedLocationJob?.cancel()
+        liveFixedLocationJob = null
         locationSyncJob?.cancel()
         locationSyncJob = null
         autoRouteJob?.cancel()
@@ -1043,15 +1051,7 @@ class MainViewModel(
 
     /** 首页地图确认选点 */
     fun confirmMapPoint(lat: Double, lng: Double) {
-        _uiState.update {
-            it.copy(
-                latitudeInput = String.format("%.6f", lat),
-                longitudeInput = String.format("%.6f", lng),
-                mapConfirmedPoint = Pair(lat, lng),
-                showCoordinateError = false
-            )
-        }
-        evaluateMockCapabilities()
+        updateSelectedLocation(lat, lng, mapPoint = Pair(lat, lng))
     }
 
     /** 清除地图选点状态 */
@@ -1211,6 +1211,8 @@ class MainViewModel(
         locationSyncJob = null
         autoRouteJob?.cancel()
         autoRouteJob = null
+        liveFixedLocationJob?.cancel()
+        liveFixedLocationJob = null
         viewModelScope.launch {
             locationRepository.stopSpoofing(context)
             _uiState.update {
@@ -1236,6 +1238,7 @@ class MainViewModel(
 
     fun loadSavedLocation(loc: SavedLocation) {
         val wifiCount = try { org.json.JSONArray(loc.wifiJson).length() } catch(e: Exception) { 0 }
+        val cellCount = try { org.json.JSONArray(loc.cellJson).length() } catch(e: Exception) { 0 }
         _uiState.update { 
             it.copy(
                 latitudeInput = String.format("%.6f", loc.lat),
@@ -1243,9 +1246,12 @@ class MainViewModel(
                 collectedWifiJson = loc.wifiJson,
                 collectedCellJson = loc.cellJson,
                 wifiApCount = wifiCount,
-                wifiLoadStatus = if (wifiCount > 0) com.suseoaa.locationspoofer.data.model.WifiLoadStatus.DONE else com.suseoaa.locationspoofer.data.model.WifiLoadStatus.IDLE
+                wifiLoadStatus = if (wifiCount > 0) com.suseoaa.locationspoofer.data.model.WifiLoadStatus.DONE else com.suseoaa.locationspoofer.data.model.WifiLoadStatus.IDLE,
+                canMockWifi = wifiCount > 0,
+                canMockCell = cellCount > 0
             ) 
         }
+        syncLiveFixedLocation(loc.lat, loc.lng, loc.wifiJson, loc.cellJson, _uiState.value.collectedBluetoothJson)
     }
 
     fun removeSavedLocation(location: SavedLocation) {
@@ -1434,6 +1440,82 @@ class MainViewModel(
                     )
                 }
             }
+        }
+    }
+
+    private fun updateSelectedLocation(
+        lat: Double,
+        lng: Double,
+        mapPoint: Pair<Double, Double>? = null
+    ) {
+        if (lng !in -180.0..180.0 || lat !in -90.0..90.0) {
+            _uiState.update { it.copy(showCoordinateError = true) }
+            return
+        }
+
+        _uiState.update {
+            it.copy(
+                latitudeInput = String.format(Locale.US, "%.6f", lat),
+                longitudeInput = String.format(Locale.US, "%.6f", lng),
+                mapConfirmedPoint = mapPoint ?: it.mapConfirmedPoint,
+                showCoordinateError = false
+            )
+        }
+
+        if (isFixedSpoofingActive()) {
+            syncLiveFixedLocation(lat, lng)
+        } else {
+            evaluateMockCapabilities()
+        }
+    }
+
+    private fun isFixedSpoofingActive(): Boolean {
+        val state = _uiState.value
+        return state.isSpoofingActive && state.routePlanStage != RoutePlanStage.RUNNING
+    }
+
+    private fun syncLiveFixedLocation(
+        lat: Double,
+        lng: Double,
+        wifiJsonOverride: String? = null,
+        cellJsonOverride: String? = null,
+        bluetoothJsonOverride: String? = null
+    ) {
+        if (!isFixedSpoofingActive()) {
+            return
+        }
+
+        settingsRepository.lastSpoofedLat = lat.toString()
+        settingsRepository.lastSpoofedLng = lng.toString()
+
+        liveFixedLocationJob?.cancel()
+        liveFixedLocationJob = viewModelScope.launch {
+            if (wifiJsonOverride == null && cellJsonOverride == null && bluetoothJsonOverride == null) {
+                evaluateMockCapabilitiesSuspend(lat, lng)
+            }
+
+            val state = _uiState.value
+            val wifiJson = wifiJsonOverride ?: state.collectedWifiJson
+            val cellJson = cellJsonOverride ?: state.collectedCellJson
+            val bluetoothJson = bluetoothJsonOverride ?: state.collectedBluetoothJson
+            val now = System.currentTimeMillis()
+            locationRepository.updateConfig(
+                lat = lat,
+                lng = lng,
+                simMode = "STILL",
+                simBearing = state.simBearing,
+                startTime = now,
+                routePoints = emptyList(),
+                isRouteMode = false,
+                appCoordinateSystems = state.appCoordinateSystems,
+                wifiJson = wifiJson,
+                cellJson = cellJson,
+                bluetoothJson = bluetoothJson,
+                mockWifi = state.mockWifi && state.canMockWifi,
+                mockCell = state.mockCell,
+                mockBluetooth = state.mockBluetooth && state.canMockBluetooth,
+                enableJitter = state.enableJitter
+            )
         }
     }
 

--- a/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
@@ -27,10 +27,13 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -78,6 +81,8 @@ class MainViewModel(
     private var autoRouteJob: Job? = null
     private var continuousScanJob: Job? = null
     private var liveFixedLocationJob: Job? = null
+    private val liveFixedLocationMutex = Mutex()
+    private val liveFixedLocationRequestId = AtomicLong(0)
 
     init {
         initialize()
@@ -1245,13 +1250,15 @@ class MainViewModel(
                 longitudeInput = String.format("%.6f", loc.lng),
                 collectedWifiJson = loc.wifiJson,
                 collectedCellJson = loc.cellJson,
+                collectedBluetoothJson = "[]",
                 wifiApCount = wifiCount,
                 wifiLoadStatus = if (wifiCount > 0) com.suseoaa.locationspoofer.data.model.WifiLoadStatus.DONE else com.suseoaa.locationspoofer.data.model.WifiLoadStatus.IDLE,
                 canMockWifi = wifiCount > 0,
-                canMockCell = cellCount > 0
+                canMockCell = cellCount > 0,
+                canMockBluetooth = false
             ) 
         }
-        syncLiveFixedLocation(loc.lat, loc.lng, loc.wifiJson, loc.cellJson, _uiState.value.collectedBluetoothJson)
+        syncLiveFixedLocation(loc.lat, loc.lng, loc.wifiJson, loc.cellJson, "[]")
     }
 
     fun removeSavedLocation(location: SavedLocation) {
@@ -1488,34 +1495,41 @@ class MainViewModel(
         settingsRepository.lastSpoofedLat = lat.toString()
         settingsRepository.lastSpoofedLng = lng.toString()
 
+        val requestId = liveFixedLocationRequestId.incrementAndGet()
         liveFixedLocationJob?.cancel()
         liveFixedLocationJob = viewModelScope.launch {
             if (wifiJsonOverride == null && cellJsonOverride == null && bluetoothJsonOverride == null) {
                 evaluateMockCapabilitiesSuspend(lat, lng)
             }
 
-            val state = _uiState.value
-            val wifiJson = wifiJsonOverride ?: state.collectedWifiJson
-            val cellJson = cellJsonOverride ?: state.collectedCellJson
-            val bluetoothJson = bluetoothJsonOverride ?: state.collectedBluetoothJson
-            val now = System.currentTimeMillis()
-            locationRepository.updateConfig(
-                lat = lat,
-                lng = lng,
-                simMode = "STILL",
-                simBearing = state.simBearing,
-                startTime = now,
-                routePoints = emptyList(),
-                isRouteMode = false,
-                appCoordinateSystems = state.appCoordinateSystems,
-                wifiJson = wifiJson,
-                cellJson = cellJson,
-                bluetoothJson = bluetoothJson,
-                mockWifi = state.mockWifi && state.canMockWifi,
-                mockCell = state.mockCell,
-                mockBluetooth = state.mockBluetooth && state.canMockBluetooth,
-                enableJitter = state.enableJitter
-            )
+            liveFixedLocationMutex.withLock {
+                if (requestId != liveFixedLocationRequestId.get() || !isFixedSpoofingActive()) {
+                    return@withLock
+                }
+
+                val state = _uiState.value
+                val wifiJson = wifiJsonOverride ?: state.collectedWifiJson
+                val cellJson = cellJsonOverride ?: state.collectedCellJson
+                val bluetoothJson = bluetoothJsonOverride ?: state.collectedBluetoothJson
+                val now = System.currentTimeMillis()
+                locationRepository.updateConfig(
+                    lat = lat,
+                    lng = lng,
+                    simMode = "STILL",
+                    simBearing = state.simBearing,
+                    startTime = now,
+                    routePoints = emptyList(),
+                    isRouteMode = false,
+                    appCoordinateSystems = state.appCoordinateSystems,
+                    wifiJson = wifiJson,
+                    cellJson = cellJson,
+                    bluetoothJson = bluetoothJson,
+                    mockWifi = state.mockWifi && state.canMockWifi,
+                    mockCell = state.mockCell,
+                    mockBluetooth = state.mockBluetooth && state.canMockBluetooth,
+                    enableJitter = state.enableJitter
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
@@ -152,7 +152,7 @@ class MainViewModel(
                             enableJitter = settingsRepository.enableJitter
                         )
                     }
-                    if (!generationCurrent || !repositoryStarted) {
+                    if (generationCurrent && !repositoryStarted) {
                         settingsRepository.setSpoofingSession(active = false, route = false)
                     }
                 } else {
@@ -1551,6 +1551,17 @@ class MainViewModel(
             return
         }
 
+        val stateBeforeSelection = _uiState.value
+        val previousOverrides = selectedEnvironmentOverrides
+        val previousPayload = EnvironmentPayload(
+            wifiJson = stateBeforeSelection.collectedWifiJson,
+            cellJson = stateBeforeSelection.collectedCellJson,
+            bluetoothJson = stateBeforeSelection.collectedBluetoothJson,
+            canMockWifi = stateBeforeSelection.canMockWifi,
+            canMockCell = stateBeforeSelection.canMockCell,
+            canMockBluetooth = stateBeforeSelection.canMockBluetooth,
+            wifiApCount = stateBeforeSelection.wifiApCount
+        )
         capabilityRequestId.incrementAndGet()
         selectedEnvironmentOverrides = overrides
         _uiState.update {
@@ -1562,17 +1573,18 @@ class MainViewModel(
             )
         }
 
-        if (overrides != EnvironmentOverrides()) {
-            applyEnvironmentPayload(mergeEnvironmentOverrides(EnvironmentPayload(), overrides))
-        }
-
         if (isFixedSpoofingActive()) {
             syncLiveFixedLocation(
                 lat,
                 lng,
-                overrides
+                overrides,
+                previousOverrides,
+                previousPayload
             )
         } else {
+            if (overrides != EnvironmentOverrides()) {
+                applyEnvironmentPayload(mergeEnvironmentOverrides(EnvironmentPayload(), overrides))
+            }
             evaluateMockCapabilities()
         }
     }
@@ -1598,14 +1610,16 @@ class MainViewModel(
     private fun syncLiveFixedLocation(
         lat: Double,
         lng: Double,
-        overrides: EnvironmentOverrides = EnvironmentOverrides()
+        overrides: EnvironmentOverrides = EnvironmentOverrides(),
+        previousOverrides: EnvironmentOverrides = EnvironmentOverrides(),
+        previousPayload: EnvironmentPayload = EnvironmentPayload()
     ) {
         if (!isFixedSpoofingActive()) {
             return
         }
 
-        settingsRepository.lastSpoofedLat = lat.toString()
-        settingsRepository.lastSpoofedLng = lng.toString()
+        val previousLat = settingsRepository.lastSpoofedLat.toDoubleOrNull()
+        val previousLng = settingsRepository.lastSpoofedLng.toDoubleOrNull()
 
         val requestId = liveFixedLocationRequestId.incrementAndGet()
         val configGeneration = configWriteGate.currentGeneration()
@@ -1620,16 +1634,16 @@ class MainViewModel(
             if (requestId != liveFixedLocationRequestId.get() || !isFixedSpoofingActive()) {
                 return@launch
             }
-            applyEnvironmentPayload(payload)
 
-            configWriteGate.runIfCurrent(configGeneration) {
+            var writeSucceeded = false
+            val generationCurrent = configWriteGate.runIfCurrent(configGeneration) {
                 if (requestId != liveFixedLocationRequestId.get() || !isFixedSpoofingActive()) {
                     return@runIfCurrent
                 }
 
                 val state = _uiState.value
                 val now = System.currentTimeMillis()
-                locationRepository.updateConfig(
+                writeSucceeded = locationRepository.updateConfig(
                     lat = lat,
                     lng = lng,
                     simMode = "STILL",
@@ -1646,6 +1660,28 @@ class MainViewModel(
                     mockBluetooth = state.mockBluetooth && payload.canMockBluetooth,
                     enableJitter = state.enableJitter
                 )
+            }
+
+            if (!generationCurrent || requestId != liveFixedLocationRequestId.get() || !isFixedSpoofingActive()) {
+                return@launch
+            }
+
+            if (writeSucceeded) {
+                settingsRepository.lastSpoofedLat = lat.toString()
+                settingsRepository.lastSpoofedLng = lng.toString()
+                applyEnvironmentPayload(payload)
+            } else {
+                selectedEnvironmentOverrides = previousOverrides
+                applyEnvironmentPayload(previousPayload)
+                if (previousLat != null && previousLng != null) {
+                    _uiState.update {
+                        it.copy(
+                            latitudeInput = String.format(Locale.US, "%.6f", previousLat),
+                            longitudeInput = String.format(Locale.US, "%.6f", previousLng),
+                            mapConfirmedPoint = Pair(previousLat, previousLng)
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
@@ -1351,7 +1351,11 @@ class MainViewModel(
     }
 
     fun loadSavedLocation(loc: SavedLocation) {
-        val overrides = EnvironmentOverrides(loc.wifiJson, loc.cellJson, loc.bluetoothJson)
+        val overrides = EnvironmentOverrides(
+            wifiJson = EnvironmentPayloads.usableWifiOverride(loc.wifiJson),
+            cellJson = EnvironmentPayloads.usableArrayOverride(loc.cellJson),
+            bluetoothJson = EnvironmentPayloads.usableArrayOverride(loc.bluetoothJson)
+        )
         updateSelectedLocation(loc.lat, loc.lng, overrides = overrides)
     }
 

--- a/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
@@ -117,8 +117,7 @@ class MainViewModel(
             if (settingsRepository.isSpoofingActive && settingsRepository.isRouteSpoofingActive) {
                 // Route progress is not persisted, so restoring it as the last fixed point is wrong.
                 // Explicitly end the stale route session instead.
-                settingsRepository.isSpoofingActive = false
-                settingsRepository.isRouteSpoofingActive = false
+                settingsRepository.setSpoofingSession(active = false, route = false)
                 configWriteGate.runIfCurrent(initializationGeneration) {
                     locationRepository.stopSpoofing(context)
                 }
@@ -154,15 +153,13 @@ class MainViewModel(
                         )
                     }
                     if (!generationCurrent || !repositoryStarted) {
-                        settingsRepository.isSpoofingActive = false
-                        settingsRepository.isRouteSpoofingActive = false
+                        settingsRepository.setSpoofingSession(active = false, route = false)
                     }
                 } else {
-                    settingsRepository.isSpoofingActive = false
-                    settingsRepository.isRouteSpoofingActive = false
+                    settingsRepository.setSpoofingSession(active = false, route = false)
                 }
             } else {
-                settingsRepository.isRouteSpoofingActive = false
+                settingsRepository.setSpoofingSession(active = false, route = false)
                 if (SpoofingService.isRunning) {
                     configWriteGate.runIfCurrent(initializationGeneration) {
                         locationRepository.stopSpoofing(context)
@@ -956,8 +953,7 @@ class MainViewModel(
             return
         }
         
-        settingsRepository.isSpoofingActive = true
-        settingsRepository.isRouteSpoofingActive = false
+        settingsRepository.setSpoofingSession(active = true, route = false)
         settingsRepository.lastSpoofedLat = lat.toString()
         settingsRepository.lastSpoofedLng = lng.toString()
         cancelLiveFixedLocationSync()
@@ -997,8 +993,7 @@ class MainViewModel(
             }
             if (!wroteConfig || !repositoryStarted) {
                 if (configGeneration == configWriteGate.currentGeneration()) {
-                    settingsRepository.isSpoofingActive = false
-                    settingsRepository.isRouteSpoofingActive = false
+                    settingsRepository.setSpoofingSession(active = false, route = false)
                     _uiState.update { it.copy(isSpoofingActive = false, isSavingConfig = false) }
                 }
                 return@launch
@@ -1017,8 +1012,7 @@ class MainViewModel(
 
     fun stopSpoofing() {
         val configGeneration = configWriteGate.beginNewGeneration()
-        settingsRepository.isSpoofingActive = false
-        settingsRepository.isRouteSpoofingActive = false
+        settingsRepository.setSpoofingSession(active = false, route = false)
         cancelLiveFixedLocationSync()
         locationSyncJob?.cancel()
         locationSyncJob = null
@@ -1267,8 +1261,7 @@ class MainViewModel(
     private fun startSimulationWithPoints(pointsToRun: List<RoutePoint>, state: AppState) {
         cancelLiveFixedLocationSync()
         val configGeneration = configWriteGate.beginNewGeneration()
-        settingsRepository.isSpoofingActive = true
-        settingsRepository.isRouteSpoofingActive = true
+        settingsRepository.setSpoofingSession(active = true, route = true)
         val startPoint = pointsToRun.first()
 
         _uiState.update {
@@ -1306,8 +1299,7 @@ class MainViewModel(
                     startAutoRouteLoop()
                 }
             } else if (configGeneration == configWriteGate.currentGeneration()) {
-                settingsRepository.isSpoofingActive = false
-                settingsRepository.isRouteSpoofingActive = false
+                settingsRepository.setSpoofingSession(active = false, route = false)
                 _uiState.update {
                     it.copy(isSpoofingActive = false, routePlanStage = RoutePlanStage.READY)
                 }
@@ -1328,8 +1320,7 @@ class MainViewModel(
 
     fun stopRoutePlanning() {
         val configGeneration = configWriteGate.beginNewGeneration()
-        settingsRepository.isSpoofingActive = false
-        settingsRepository.isRouteSpoofingActive = false
+        settingsRepository.setSpoofingSession(active = false, route = false)
         locationSyncJob?.cancel()
         locationSyncJob = null
         autoRouteJob?.cancel()

--- a/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
@@ -17,6 +17,9 @@ import com.suseoaa.locationspoofer.data.repository.LocationRepository
 import com.suseoaa.locationspoofer.data.repository.SettingsRepository
 import com.suseoaa.locationspoofer.provider.SpooferProvider
 import com.suseoaa.locationspoofer.service.SpoofingService
+import com.suseoaa.locationspoofer.utils.ConfigWriteGate
+import com.suseoaa.locationspoofer.utils.EnvironmentPayloads
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -27,8 +30,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
@@ -81,8 +82,26 @@ class MainViewModel(
     private var autoRouteJob: Job? = null
     private var continuousScanJob: Job? = null
     private var liveFixedLocationJob: Job? = null
-    private val liveFixedLocationMutex = Mutex()
     private val liveFixedLocationRequestId = AtomicLong(0)
+    private val capabilityRequestId = AtomicLong(0)
+    private val configWriteGate = ConfigWriteGate()
+    private var selectedEnvironmentOverrides = EnvironmentOverrides()
+
+    private data class EnvironmentPayload(
+        val wifiJson: String = "[]",
+        val cellJson: String = "[]",
+        val bluetoothJson: String = "[]",
+        val canMockWifi: Boolean = false,
+        val canMockCell: Boolean = false,
+        val canMockBluetooth: Boolean = false,
+        val wifiApCount: Int = 0
+    )
+
+    private data class EnvironmentOverrides(
+        val wifiJson: String? = null,
+        val cellJson: String? = null,
+        val bluetoothJson: String? = null
+    )
 
     init {
         initialize()
@@ -91,26 +110,51 @@ class MainViewModel(
     // 初始化
 
     private fun initialize() {
+        val initializationGeneration = configWriteGate.currentGeneration()
         viewModelScope.launch(Dispatchers.IO) {
             val root = locationRepository.checkRootAccess()
 
             if (settingsRepository.isSpoofingActive) {
-                val lastLat = settingsRepository.lastSpoofedLat.toDoubleOrNull() ?: 0.0
-                val lastLng = settingsRepository.lastSpoofedLng.toDoubleOrNull() ?: 0.0
-                if (lastLat != 0.0 && lastLng != 0.0) {
-                    locationRepository.startSpoofing(
-                        context, lastLat, lastLng,
-                        "STILL", 0f, System.currentTimeMillis(),
-                        emptyList(), false,
-                        settingsRepository.getAppCoordinateSystems(),
-                        mockWifi = settingsRepository.mockWifi,
-                        mockCell = settingsRepository.mockCell,
-                        mockBluetooth = settingsRepository.mockBluetooth,
-                        enableJitter = settingsRepository.enableJitter
+                val lastLat = settingsRepository.lastSpoofedLat.toDoubleOrNull()
+                val lastLng = settingsRepository.lastSpoofedLng.toDoubleOrNull()
+                if (lastLat != null && lastLng != null &&
+                    lastLat in -90.0..90.0 && lastLng in -180.0..180.0
+                ) {
+                    val payload = prepareEnvironmentPayload(
+                        lat = lastLat,
+                        lng = lastLng,
+                        overrides = EnvironmentOverrides(),
+                        fetchRemote = true
                     )
+                    if (initializationGeneration == configWriteGate.currentGeneration()) {
+                        applyEnvironmentPayload(payload)
+                    }
+                    var repositoryStarted = false
+                    val generationCurrent = configWriteGate.runIfCurrent(initializationGeneration) {
+                        repositoryStarted = locationRepository.startSpoofing(
+                            context, lastLat, lastLng,
+                            "STILL", 0f, System.currentTimeMillis(),
+                            emptyList(), false,
+                            settingsRepository.getAppCoordinateSystems(),
+                            wifiJson = payload.wifiJson,
+                            cellJson = payload.cellJson,
+                            bluetoothJson = payload.bluetoothJson,
+                            mockWifi = settingsRepository.mockWifi && payload.canMockWifi,
+                            mockCell = settingsRepository.mockCell,
+                            mockBluetooth = settingsRepository.mockBluetooth && payload.canMockBluetooth,
+                            enableJitter = settingsRepository.enableJitter
+                        )
+                    }
+                    if (!generationCurrent || !repositoryStarted) {
+                        settingsRepository.isSpoofingActive = false
+                    }
+                } else {
+                    settingsRepository.isSpoofingActive = false
                 }
             } else if (SpoofingService.isRunning) {
-                locationRepository.stopSpoofing(context)
+                configWriteGate.runIfCurrent(initializationGeneration) {
+                    locationRepository.stopSpoofing(context)
+                }
             }
 
             _uiState.update {
@@ -294,13 +338,7 @@ class MainViewModel(
                 client.setLocationListener { loc ->
                     if (loc != null && loc.errorCode == 0) {
                         if (_uiState.value.longitudeInput.isEmpty() || _uiState.value.latitudeInput.isEmpty() || forceCallback != null) {
-                            _uiState.update {
-                                it.copy(
-                                    latitudeInput = String.format("%.6f", loc.latitude),
-                                    longitudeInput = String.format("%.6f", loc.longitude),
-                                    showCoordinateError = false
-                                )
-                            }
+                            updateSelectedLocation(loc.latitude, loc.longitude)
                             forceCallback?.invoke(loc.latitude, loc.longitude)
                         }
                     } else {
@@ -355,6 +393,8 @@ class MainViewModel(
             if (forceCallback != null) {
                 android.widget.Toast.makeText(ctx, ctx.getString(com.suseoaa.locationspoofer.R.string.location_permission_denied), android.widget.Toast.LENGTH_SHORT).show()
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             e.printStackTrace()
         }
@@ -375,13 +415,7 @@ class MainViewModel(
         }
 
         if (_uiState.value.longitudeInput.isEmpty() || _uiState.value.latitudeInput.isEmpty() || forceCallback != null) {
-            _uiState.update {
-                it.copy(
-                    latitudeInput = String.format("%.6f", finalLat),
-                    longitudeInput = String.format("%.6f", finalLng),
-                    showCoordinateError = false
-                )
-            }
+            updateSelectedLocation(finalLat, finalLng)
             forceCallback?.invoke(finalLat, finalLng)
         }
     }
@@ -481,6 +515,7 @@ class MainViewModel(
 
     fun updateLongitude(value: String) {
         if (isValidCoord(value)) {
+            selectedEnvironmentOverrides = EnvironmentOverrides()
             _uiState.update { it.copy(longitudeInput = value, showCoordinateError = false) }
             evaluateMockCapabilities()
         }
@@ -488,6 +523,7 @@ class MainViewModel(
 
     fun updateLatitude(value: String) {
         if (isValidCoord(value)) {
+            selectedEnvironmentOverrides = EnvironmentOverrides()
             _uiState.update { it.copy(latitudeInput = value, showCoordinateError = false) }
             evaluateMockCapabilities()
         }
@@ -508,6 +544,7 @@ class MainViewModel(
         val lng = state.longitudeInput.toDoubleOrNull()
         
         if (lat == null || lng == null) {
+            capabilityRequestId.incrementAndGet()
             _uiState.update { 
                 it.copy(canMockWifi = false, canMockCell = false, canMockBluetooth = false, 
                         collectedWifiJson = "[]", collectedCellJson = "[]", collectedBluetoothJson = "[]",
@@ -516,12 +553,21 @@ class MainViewModel(
             return
         }
         
+        val requestId = capabilityRequestId.incrementAndGet()
+        val overrides = selectedEnvironmentOverrides
         viewModelScope.launch {
-            evaluateMockCapabilitiesSuspend(lat, lng)
+            val payload = loadEnvironmentPayload(lat, lng, overrides)
+            if (requestId == capabilityRequestId.get()) {
+                withContext(Dispatchers.Main) { applyEnvironmentPayload(payload) }
+            }
         }
     }
 
-    private suspend fun evaluateMockCapabilitiesSuspend(lat: Double, lng: Double) {
+    private suspend fun loadEnvironmentPayload(
+        lat: Double,
+        lng: Double,
+        overrides: EnvironmentOverrides = EnvironmentOverrides()
+    ): EnvironmentPayload {
         val allRecords = withContext(Dispatchers.IO) { environmentDao.getAllCompleteLocations() }
         val validRecords = mutableListOf<com.suseoaa.locationspoofer.data.db.CompleteLocation>()
 
@@ -540,54 +586,63 @@ class MainViewModel(
             }
         }
 
-        withContext(Dispatchers.Main) {
-            if (validRecords.isEmpty()) {
-                _uiState.update {
-                    it.copy(
-                        canMockWifi = false, canMockCell = false, canMockBluetooth = false,
-                        collectedWifiJson = "[]", collectedCellJson = "[]", collectedBluetoothJson = "[]",
-                        wifiApCount = 0,
-                        wifiLoadStatus = com.suseoaa.locationspoofer.data.model.WifiLoadStatus.IDLE
-                    )
-                }
-            } else {
-                val (wifiJson, cellJson, btJson) = locationToJson(validRecords, lat, lng)
-                val hasW = try {
-                    val obj = org.json.JSONObject(wifiJson)
-                    val nearby = obj.optJSONArray("nearbyWifi")
-                    val connected = obj.opt("connectedWifi")
-                    (nearby != null && nearby.length() > 0) || (connected != null && !obj.isNull("connectedWifi"))
-                } catch (e: Exception) {
-                    false
-                }
-                val hasC = try {
-                    val arr = org.json.JSONArray(cellJson)
-                    arr.length() > 0
-                } catch (e: Exception) {
-                    false
-                }
-                val hasB = try {
-                    val arr = org.json.JSONArray(btJson)
-                    arr.length() > 0
-                } catch (e: Exception) {
-                    false
-                }
+        val localPayload = if (validRecords.isEmpty()) {
+            EnvironmentPayload()
+        } else {
+            val (wifiJson, cellJson, bluetoothJson) = locationToJson(validRecords, lat, lng)
+            environmentPayload(wifiJson, cellJson, bluetoothJson)
+        }
+        return mergeEnvironmentOverrides(localPayload, overrides)
+    }
 
-                val wifiCount = try {
-                    val obj = org.json.JSONObject(wifiJson)
-                    val nearby = obj.optJSONArray("nearbyWifi")
-                    nearby?.length() ?: 0
-                } catch (e: Exception) { 0 }
+    private fun environmentPayload(
+        wifiJson: String,
+        cellJson: String,
+        bluetoothJson: String
+    ): EnvironmentPayload {
+        val wifiInfo = EnvironmentPayloads.inspectWifi(wifiJson)
+        return EnvironmentPayload(
+            wifiJson = wifiJson,
+            cellJson = cellJson,
+            bluetoothJson = bluetoothJson,
+            canMockWifi = wifiInfo.hasData,
+            canMockCell = EnvironmentPayloads.hasArrayItems(cellJson),
+            canMockBluetooth = EnvironmentPayloads.hasArrayItems(bluetoothJson),
+            wifiApCount = wifiInfo.nearbyCount
+        )
+    }
 
-                _uiState.update {
-                    it.copy(
-                        canMockWifi = hasW, canMockCell = hasC, canMockBluetooth = hasB,
-                        collectedWifiJson = wifiJson, collectedCellJson = cellJson, collectedBluetoothJson = btJson,
-                        wifiApCount = wifiCount,
-                        wifiLoadStatus = if (hasW) com.suseoaa.locationspoofer.data.model.WifiLoadStatus.DONE else com.suseoaa.locationspoofer.data.model.WifiLoadStatus.IDLE
-                    )
+    private fun mergeEnvironmentOverrides(
+        local: EnvironmentPayload,
+        overrides: EnvironmentOverrides
+    ): EnvironmentPayload {
+        val merged = EnvironmentPayloads.merge(
+            localWifiJson = local.wifiJson,
+            localCellJson = local.cellJson,
+            localBluetoothJson = local.bluetoothJson,
+            wifiJsonOverride = overrides.wifiJson,
+            cellJsonOverride = overrides.cellJson,
+            bluetoothJsonOverride = overrides.bluetoothJson
+        )
+        return environmentPayload(merged.wifiJson, merged.cellJson, merged.bluetoothJson)
+    }
+
+    private fun applyEnvironmentPayload(payload: EnvironmentPayload) {
+        _uiState.update {
+            it.copy(
+                canMockWifi = payload.canMockWifi,
+                canMockCell = payload.canMockCell,
+                canMockBluetooth = payload.canMockBluetooth,
+                collectedWifiJson = payload.wifiJson,
+                collectedCellJson = payload.cellJson,
+                collectedBluetoothJson = payload.bluetoothJson,
+                wifiApCount = payload.wifiApCount,
+                wifiLoadStatus = if (payload.canMockWifi) {
+                    com.suseoaa.locationspoofer.data.model.WifiLoadStatus.DONE
+                } else {
+                    com.suseoaa.locationspoofer.data.model.WifiLoadStatus.IDLE
                 }
-            }
+            )
         }
     }
 
@@ -627,7 +682,7 @@ class MainViewModel(
                 val cellInfoStr = record.cells.map { cell ->
                     "Type: ${cell.device.type}, MCC: ${cell.device.mcc}, MNC: ${cell.device.mnc}, LAC: ${cell.device.lac}, CID: ${cell.device.cid}, DBM: ${cell.locationCell.dbm}"
                 }.joinToString("; ")
-                android.util.Log.d("OpenCellID", "hasLocalCellsWithin50m: Found cached cells within 50m of ($lat, $lng) at location ID ${record.location.id}. Distance: ${String.format("%.2f", distance)}m, Cell Count: $cellCount. Bypassing network request. Cached cells: $cellInfoStr")
+                android.util.Log.d("OpenCellID", "hasLocalCellsWithin50m: Found cached cells within 50m of ($lat, $lng) at location ID ${record.location.id}. Distance: ${String.format(Locale.US, "%.2f", distance)}m, Cell Count: $cellCount. Bypassing network request. Cached cells: $cellInfoStr")
                 return true
             }
         }
@@ -712,18 +767,12 @@ class MainViewModel(
                     // update metadata to indicate WiGLE source
                     val newestLocation = environmentDao.getAllLocations().firstOrNull { it.lat == lat && it.lng == lng }
                     if (newestLocation != null) {
-                        environmentDao.updateMetadata(newestLocation.id, "WiGLE 导入", "经纬度: (${String.format("%.6f", lat)}, ${String.format("%.6f", lng)})")
+                        environmentDao.updateMetadata(newestLocation.id, "WiGLE 导入", "经纬度: (${String.format(Locale.US, "%.6f", lat)}, ${String.format(Locale.US, "%.6f", lng)})")
                     }
                 }
                 
-                withContext(Dispatchers.Main) {
-                    evaluateMockCapabilities()
-                    // Refresh count
-                    viewModelScope.launch(Dispatchers.IO) {
-                        val count = environmentDao.getRecordCount()
-                        _uiState.update { it.copy(environmentRecordCount = count) }
-                    }
-                }
+                val count = withContext(Dispatchers.IO) { environmentDao.getRecordCount() }
+                _uiState.update { it.copy(environmentRecordCount = count) }
             } else {
                 withContext(Dispatchers.Main) {
                     _uiState.update {
@@ -735,6 +784,8 @@ class MainViewModel(
                     }
                 }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             e.printStackTrace()
             withContext(Dispatchers.Main) {
@@ -776,20 +827,16 @@ class MainViewModel(
                     saveEnvironmentData(lat, lng, "{}", formattedCells.toString(), "[]")
                     val newestLocation = environmentDao.getAllLocations().firstOrNull { it.lat == lat && it.lng == lng }
                     if (newestLocation != null) {
-                        environmentDao.updateMetadata(newestLocation.id, "OpenCellID 导入", "经纬度: (${String.format("%.6f", lat)}, ${String.format("%.6f", lng)})")
+                        environmentDao.updateMetadata(newestLocation.id, "OpenCellID 导入", "经纬度: (${String.format(Locale.US, "%.6f", lat)}, ${String.format(Locale.US, "%.6f", lng)})")
                     }
                     android.util.Log.d("OpenCellID", "fetchCellFromOpenCellIdSync: Successfully inserted ${formattedCells.length()} cells into database.")
                 }
 
-                withContext(Dispatchers.Main) {
-                    evaluateMockCapabilities()
-                    // Refresh count
-                    viewModelScope.launch(Dispatchers.IO) {
-                        val count = environmentDao.getRecordCount()
-                        _uiState.update { it.copy(environmentRecordCount = count) }
-                    }
-                }
+                val count = withContext(Dispatchers.IO) { environmentDao.getRecordCount() }
+                _uiState.update { it.copy(environmentRecordCount = count) }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             e.printStackTrace()
         }
@@ -862,6 +909,22 @@ class MainViewModel(
         return (-70 - index * 3).coerceAtLeast(-110)
     }
 
+    private suspend fun prepareEnvironmentPayload(
+        lat: Double,
+        lng: Double,
+        overrides: EnvironmentOverrides,
+        fetchRemote: Boolean
+    ): EnvironmentPayload {
+        val state = _uiState.value
+        if (fetchRemote && overrides.wifiJson == null && state.mockWifi && !hasLocalWifiWithin50m(lat, lng)) {
+            fetchWifiFromWigleSync(lat, lng)
+        }
+        if (fetchRemote && overrides.cellJson == null && state.mockCell && !hasLocalCellsWithin50m(lat, lng)) {
+            fetchCellFromOpenCellIdSync(lat, lng)
+        }
+        return loadEnvironmentPayload(lat, lng, overrides)
+    }
+
     // 定点模拟
 
     @android.annotation.SuppressLint("MissingPermission")
@@ -883,56 +946,74 @@ class MainViewModel(
         settingsRepository.isSpoofingActive = true
         settingsRepository.lastSpoofedLat = lat.toString()
         settingsRepository.lastSpoofedLng = lng.toString()
+        cancelLiveFixedLocationSync()
+        val configGeneration = configWriteGate.beginNewGeneration()
         
         viewModelScope.launch {
             _uiState.update { it.copy(isSavingConfig = true) }
             
-            if (state.mockWifi && !hasLocalWifiWithin50m(lat, lng)) {
-                fetchWifiFromWigleSync(lat, lng)
+            val payload = prepareEnvironmentPayload(
+                lat = lat,
+                lng = lng,
+                overrides = selectedEnvironmentOverrides,
+                fetchRemote = true
+            )
+            applyEnvironmentPayload(payload)
+            if (configGeneration != configWriteGate.currentGeneration()) {
+                return@launch
             }
-            if (state.mockCell && !hasLocalCellsWithin50m(lat, lng)) {
-                fetchCellFromOpenCellIdSync(lat, lng)
-            }
-
-            evaluateMockCapabilitiesSuspend(lat, lng)
             
             val updatedState = _uiState.value
             val now = System.currentTimeMillis()
-            locationRepository.startSpoofing(
-                context, lat, lng,
-                "STILL", 0f, now,
-                emptyList(), false,
-                updatedState.appCoordinateSystems,
-                updatedState.collectedWifiJson,
-                updatedState.collectedCellJson,
-                updatedState.collectedBluetoothJson,
-                updatedState.mockWifi && updatedState.canMockWifi,
-                updatedState.mockCell,
-                updatedState.mockBluetooth && updatedState.canMockBluetooth,
-                updatedState.enableJitter
-            )
+            var repositoryStarted = false
+            val wroteConfig = configWriteGate.runIfCurrent(configGeneration) {
+                repositoryStarted = locationRepository.startSpoofing(
+                    context, lat, lng,
+                    "STILL", 0f, now,
+                    emptyList(), false,
+                    updatedState.appCoordinateSystems,
+                    updatedState.collectedWifiJson,
+                    updatedState.collectedCellJson,
+                    updatedState.collectedBluetoothJson,
+                    updatedState.mockWifi && updatedState.canMockWifi,
+                    updatedState.mockCell,
+                    updatedState.mockBluetooth && updatedState.canMockBluetooth,
+                    updatedState.enableJitter
+                )
+            }
+            if (!wroteConfig || !repositoryStarted) {
+                if (configGeneration == configWriteGate.currentGeneration()) {
+                    settingsRepository.isSpoofingActive = false
+                    _uiState.update { it.copy(isSpoofingActive = false, isSavingConfig = false) }
+                }
+                return@launch
+            }
             
             // Wait briefly to ensure root shell syncs to disk fully
             kotlinx.coroutines.delay(200)
 
-            _uiState.update {
-                it.copy(isSpoofingActive = true, isSavingConfig = false)
+            if (configGeneration == configWriteGate.currentGeneration()) {
+                _uiState.update {
+                    it.copy(isSpoofingActive = true, isSavingConfig = false)
+                }
             }
         }
     }
 
     fun stopSpoofing() {
+        val configGeneration = configWriteGate.beginNewGeneration()
         settingsRepository.isSpoofingActive = false
-        liveFixedLocationJob?.cancel()
-        liveFixedLocationJob = null
+        cancelLiveFixedLocationSync()
         locationSyncJob?.cancel()
         locationSyncJob = null
         autoRouteJob?.cancel()
         autoRouteJob = null
+        _uiState.update {
+            it.copy(isSpoofingActive = false, isSavingConfig = false)
+        }
         viewModelScope.launch {
-            locationRepository.stopSpoofing(context)
-            _uiState.update {
-                it.copy(isSpoofingActive = false)
+            configWriteGate.runIfCurrent(configGeneration) {
+                locationRepository.stopSpoofing(context)
             }
         }
     }
@@ -960,8 +1041,8 @@ class MainViewModel(
         val newLng = Math.toDegrees(newLngRad)
         _uiState.update {
             it.copy(
-                latitudeInput = String.format("%.6f", newLat),
-                longitudeInput = String.format("%.6f", newLng),
+                latitudeInput = String.format(Locale.US, "%.6f", newLat),
+                longitudeInput = String.format(Locale.US, "%.6f", newLng),
                 simBearing = bearing.toFloat(),
                 showCoordinateError = false
             )
@@ -977,6 +1058,7 @@ class MainViewModel(
 
     /** 进入全屏地图，进入选点阶段 */
     fun enterRoutePlanning() {
+        cancelLiveFixedLocationSync()
         _uiState.update {
             it.copy(
                 routePlanStage = RoutePlanStage.SELECTING,
@@ -1167,12 +1249,15 @@ class MainViewModel(
     }
 
     private fun startSimulationWithPoints(pointsToRun: List<RoutePoint>, state: AppState) {
+        cancelLiveFixedLocationSync()
+        val configGeneration = configWriteGate.beginNewGeneration()
+        settingsRepository.isSpoofingActive = true
         val startPoint = pointsToRun.first()
 
         _uiState.update {
             it.copy(
-                latitudeInput = String.format("%.6f", startPoint.lat),
-                longitudeInput = String.format("%.6f", startPoint.lng),
+                latitudeInput = String.format(Locale.US, "%.6f", startPoint.lat),
+                longitudeInput = String.format(Locale.US, "%.6f", startPoint.lng),
                 routePlanStage = RoutePlanStage.RUNNING,
                 routePoints = pointsToRun
             )
@@ -1182,21 +1267,33 @@ class MainViewModel(
 
         viewModelScope.launch {
             val now = System.currentTimeMillis()
-            
-            locationRepository.startSpoofing(
-                context, startPoint.lat, startPoint.lng,
-                if (isLoop) state.routeSimMode.name else "STILL",
-                0f, now, pointsToRun, isLoop, state.appCoordinateSystems,
-                state.collectedWifiJson, state.collectedCellJson, state.collectedBluetoothJson,
-                state.mockWifi, state.mockCell, state.mockBluetooth, state.enableJitter
-            )
-            _uiState.update {
-                it.copy(isSpoofingActive = true)
-            }
-        }
 
-        if (isLoop) {
-            startAutoRouteLoop()
+            var repositoryStarted = false
+            val generationCurrent = configWriteGate.runIfCurrent(configGeneration) {
+                repositoryStarted = locationRepository.startSpoofing(
+                    context, startPoint.lat, startPoint.lng,
+                    if (isLoop) state.routeSimMode.name else "STILL",
+                    0f, now, pointsToRun, isLoop, state.appCoordinateSystems,
+                    state.collectedWifiJson, state.collectedCellJson, state.collectedBluetoothJson,
+                    state.mockWifi && state.canMockWifi,
+                    state.mockCell,
+                    state.mockBluetooth && state.canMockBluetooth,
+                    state.enableJitter
+                )
+            }
+            if (generationCurrent && repositoryStarted && configGeneration == configWriteGate.currentGeneration()) {
+                _uiState.update {
+                    it.copy(isSpoofingActive = true)
+                }
+                if (isLoop) {
+                    startAutoRouteLoop()
+                }
+            } else if (configGeneration == configWriteGate.currentGeneration()) {
+                settingsRepository.isSpoofingActive = false
+                _uiState.update {
+                    it.copy(isSpoofingActive = false, routePlanStage = RoutePlanStage.READY)
+                }
+            }
         }
     }
 
@@ -1212,21 +1309,24 @@ class MainViewModel(
     }
 
     fun stopRoutePlanning() {
+        val configGeneration = configWriteGate.beginNewGeneration()
+        settingsRepository.isSpoofingActive = false
         locationSyncJob?.cancel()
         locationSyncJob = null
         autoRouteJob?.cancel()
         autoRouteJob = null
-        liveFixedLocationJob?.cancel()
-        liveFixedLocationJob = null
+        cancelLiveFixedLocationSync()
+        _uiState.update {
+            it.copy(
+                isSpoofingActive = false,
+                routePlanStage = RoutePlanStage.IDLE,
+                routePoints = emptyList(),
+                routeRunMode = RouteRunMode.MANUAL
+            )
+        }
         viewModelScope.launch {
-            locationRepository.stopSpoofing(context)
-            _uiState.update {
-                it.copy(
-                    isSpoofingActive = false,
-                    routePlanStage = RoutePlanStage.IDLE,
-                    routePoints = emptyList(),
-                    routeRunMode = RouteRunMode.MANUAL
-                )
+            configWriteGate.runIfCurrent(configGeneration) {
+                locationRepository.stopSpoofing(context)
             }
         }
     }
@@ -1237,28 +1337,22 @@ class MainViewModel(
         val lng = _uiState.value.longitudeInput.toDoubleOrNull() ?: return
         val lat = _uiState.value.latitudeInput.toDoubleOrNull() ?: return
         val state = _uiState.value
-        settingsRepository.addSavedLocation(SavedLocation(name, lat, lng, state.collectedWifiJson, state.collectedCellJson))
+        settingsRepository.addSavedLocation(
+            SavedLocation(
+                name = name,
+                lat = lat,
+                lng = lng,
+                wifiJson = state.collectedWifiJson,
+                cellJson = state.collectedCellJson,
+                bluetoothJson = state.collectedBluetoothJson
+            )
+        )
         _uiState.update { it.copy(savedLocations = settingsRepository.getSavedLocations()) }
     }
 
     fun loadSavedLocation(loc: SavedLocation) {
-        val wifiCount = try { org.json.JSONArray(loc.wifiJson).length() } catch(e: Exception) { 0 }
-        val cellCount = try { org.json.JSONArray(loc.cellJson).length() } catch(e: Exception) { 0 }
-        _uiState.update { 
-            it.copy(
-                latitudeInput = String.format("%.6f", loc.lat),
-                longitudeInput = String.format("%.6f", loc.lng),
-                collectedWifiJson = loc.wifiJson,
-                collectedCellJson = loc.cellJson,
-                collectedBluetoothJson = "[]",
-                wifiApCount = wifiCount,
-                wifiLoadStatus = if (wifiCount > 0) com.suseoaa.locationspoofer.data.model.WifiLoadStatus.DONE else com.suseoaa.locationspoofer.data.model.WifiLoadStatus.IDLE,
-                canMockWifi = wifiCount > 0,
-                canMockCell = cellCount > 0,
-                canMockBluetooth = false
-            ) 
-        }
-        syncLiveFixedLocation(loc.lat, loc.lng, loc.wifiJson, loc.cellJson, "[]")
+        val overrides = EnvironmentOverrides(loc.wifiJson, loc.cellJson, loc.bluetoothJson)
+        updateSelectedLocation(loc.lat, loc.lng, overrides = overrides)
     }
 
     fun removeSavedLocation(location: SavedLocation) {
@@ -1366,8 +1460,8 @@ class MainViewModel(
     private fun updatePosition(lat: Double, lng: Double, bearing: Float) {
         _uiState.update {
             it.copy(
-                latitudeInput = String.format("%.6f", lat),
-                longitudeInput = String.format("%.6f", lng),
+                latitudeInput = String.format(Locale.US, "%.6f", lat),
+                longitudeInput = String.format(Locale.US, "%.6f", lng),
                 simBearing = bearing,
                 showCoordinateError = false
             )
@@ -1386,9 +1480,10 @@ class MainViewModel(
         if (distance > 20.0) {
             lastDbQueryLat = lat
             lastDbQueryLng = lng
+            val configGeneration = configWriteGate.currentGeneration()
             viewModelScope.launch(Dispatchers.IO) {
                 val records = environmentDao.getNearestLocations(lat, lng, 3)
-                if (records.isNotEmpty()) {
+                val environmentJson = if (records.isNotEmpty()) {
                     val record = records[0]
                     // Check if the closest record is actually within ~50 meters
                     val rLat = Math.toRadians(record.location.lat - lat)
@@ -1398,52 +1493,33 @@ class MainViewModel(
                     
                     if (rDist <= 50.0) {
                         val jsons = locationToJson(records, lat, lng)
-                        SpooferProvider.cellJson = jsons.second
-                        // Save config file with new cell_json and wifi_json and bluetoothJson
-                        locationRepository.updateConfig(
-                            lat = lat,
-                            lng = lng,
-                            simMode = "STILL",
-                            simBearing = bearing,
-                            startTime = SpooferProvider.startTimestamp,
-                            routePoints = _uiState.value.routePoints,
-                            isRouteMode = _uiState.value.routePlanStage == com.suseoaa.locationspoofer.data.model.RoutePlanStage.RUNNING,
-                            appCoordinateSystems = settingsRepository.getAppCoordinateSystems(),
-                            wifiJson = jsons.first,
-                            cellJson = jsons.second,
-                            bluetoothJson = jsons.third
-                        )
+                        jsons
                     } else {
                         // Fallback to random cell generation
-                        SpooferProvider.cellJson = "[]"
-                        locationRepository.updateConfig(
-                            lat = lat,
-                            lng = lng,
-                            simMode = "STILL",
-                            simBearing = bearing,
-                            startTime = SpooferProvider.startTimestamp,
-                            routePoints = _uiState.value.routePoints,
-                            isRouteMode = _uiState.value.routePlanStage == com.suseoaa.locationspoofer.data.model.RoutePlanStage.RUNNING,
-                            appCoordinateSystems = settingsRepository.getAppCoordinateSystems(),
-                            wifiJson = "[]",
-                            cellJson = "[]",
-                            bluetoothJson = "[]"
-                        )
+                        Triple("[]", "[]", "[]")
                     }
                 } else {
-                    SpooferProvider.cellJson = "[]"
+                    Triple("[]", "[]", "[]")
+                }
+
+                configWriteGate.runIfCurrent(configGeneration) {
+                    val state = _uiState.value
                     locationRepository.updateConfig(
                         lat = lat,
                         lng = lng,
                         simMode = "STILL",
                         simBearing = bearing,
                         startTime = SpooferProvider.startTimestamp,
-                        routePoints = _uiState.value.routePoints,
-                        isRouteMode = _uiState.value.routePlanStage == com.suseoaa.locationspoofer.data.model.RoutePlanStage.RUNNING,
+                        routePoints = state.routePoints,
+                        isRouteMode = state.routePlanStage == com.suseoaa.locationspoofer.data.model.RoutePlanStage.RUNNING,
                         appCoordinateSystems = settingsRepository.getAppCoordinateSystems(),
-                        wifiJson = "[]",
-                        cellJson = "[]",
-                        bluetoothJson = "[]"
+                        wifiJson = environmentJson.first,
+                        cellJson = environmentJson.second,
+                        bluetoothJson = environmentJson.third,
+                        mockWifi = state.mockWifi && EnvironmentPayloads.inspectWifi(environmentJson.first).hasData,
+                        mockCell = state.mockCell,
+                        mockBluetooth = state.mockBluetooth && EnvironmentPayloads.hasArrayItems(environmentJson.third),
+                        enableJitter = state.enableJitter
                     )
                 }
             }
@@ -1453,13 +1529,16 @@ class MainViewModel(
     private fun updateSelectedLocation(
         lat: Double,
         lng: Double,
-        mapPoint: Pair<Double, Double>? = null
+        mapPoint: Pair<Double, Double>? = null,
+        overrides: EnvironmentOverrides = EnvironmentOverrides()
     ) {
         if (lng !in -180.0..180.0 || lat !in -90.0..90.0) {
             _uiState.update { it.copy(showCoordinateError = true) }
             return
         }
 
+        capabilityRequestId.incrementAndGet()
+        selectedEnvironmentOverrides = overrides
         _uiState.update {
             it.copy(
                 latitudeInput = String.format(Locale.US, "%.6f", lat),
@@ -1469,8 +1548,16 @@ class MainViewModel(
             )
         }
 
+        if (overrides != EnvironmentOverrides()) {
+            applyEnvironmentPayload(mergeEnvironmentOverrides(EnvironmentPayload(), overrides))
+        }
+
         if (isFixedSpoofingActive()) {
-            syncLiveFixedLocation(lat, lng)
+            syncLiveFixedLocation(
+                lat,
+                lng,
+                overrides
+            )
         } else {
             evaluateMockCapabilities()
         }
@@ -1478,15 +1565,26 @@ class MainViewModel(
 
     private fun isFixedSpoofingActive(): Boolean {
         val state = _uiState.value
-        return state.isSpoofingActive && state.routePlanStage != RoutePlanStage.RUNNING
+        return state.isSpoofingActive && state.routePlanStage == RoutePlanStage.IDLE
+    }
+
+    private fun cancelLiveFixedLocationSync() {
+        liveFixedLocationRequestId.incrementAndGet()
+        liveFixedLocationJob?.cancel()
+        liveFixedLocationJob = null
+        _uiState.update { state ->
+            if (state.wifiLoadStatus == com.suseoaa.locationspoofer.data.model.WifiLoadStatus.LOADING) {
+                state.copy(wifiLoadStatus = com.suseoaa.locationspoofer.data.model.WifiLoadStatus.IDLE)
+            } else {
+                state
+            }
+        }
     }
 
     private fun syncLiveFixedLocation(
         lat: Double,
         lng: Double,
-        wifiJsonOverride: String? = null,
-        cellJsonOverride: String? = null,
-        bluetoothJsonOverride: String? = null
+        overrides: EnvironmentOverrides = EnvironmentOverrides()
     ) {
         if (!isFixedSpoofingActive()) {
             return
@@ -1496,21 +1594,26 @@ class MainViewModel(
         settingsRepository.lastSpoofedLng = lng.toString()
 
         val requestId = liveFixedLocationRequestId.incrementAndGet()
+        val configGeneration = configWriteGate.currentGeneration()
         liveFixedLocationJob?.cancel()
         liveFixedLocationJob = viewModelScope.launch {
-            if (wifiJsonOverride == null && cellJsonOverride == null && bluetoothJsonOverride == null) {
-                evaluateMockCapabilitiesSuspend(lat, lng)
+            val payload = prepareEnvironmentPayload(
+                lat = lat,
+                lng = lng,
+                overrides = overrides,
+                fetchRemote = true
+            )
+            if (requestId != liveFixedLocationRequestId.get() || !isFixedSpoofingActive()) {
+                return@launch
             }
+            applyEnvironmentPayload(payload)
 
-            liveFixedLocationMutex.withLock {
+            configWriteGate.runIfCurrent(configGeneration) {
                 if (requestId != liveFixedLocationRequestId.get() || !isFixedSpoofingActive()) {
-                    return@withLock
+                    return@runIfCurrent
                 }
 
                 val state = _uiState.value
-                val wifiJson = wifiJsonOverride ?: state.collectedWifiJson
-                val cellJson = cellJsonOverride ?: state.collectedCellJson
-                val bluetoothJson = bluetoothJsonOverride ?: state.collectedBluetoothJson
                 val now = System.currentTimeMillis()
                 locationRepository.updateConfig(
                     lat = lat,
@@ -1521,12 +1624,12 @@ class MainViewModel(
                     routePoints = emptyList(),
                     isRouteMode = false,
                     appCoordinateSystems = state.appCoordinateSystems,
-                    wifiJson = wifiJson,
-                    cellJson = cellJson,
-                    bluetoothJson = bluetoothJson,
-                    mockWifi = state.mockWifi && state.canMockWifi,
+                    wifiJson = payload.wifiJson,
+                    cellJson = payload.cellJson,
+                    bluetoothJson = payload.bluetoothJson,
+                    mockWifi = state.mockWifi && payload.canMockWifi,
                     mockCell = state.mockCell,
-                    mockBluetooth = state.mockBluetooth && state.canMockBluetooth,
+                    mockBluetooth = state.mockBluetooth && payload.canMockBluetooth,
                     enableJitter = state.enableJitter
                 )
             }
@@ -1581,27 +1684,30 @@ class MainViewModel(
     
     private fun syncMockSettings() {
         if (_uiState.value.isSpoofingActive) {
-            val state = _uiState.value
-            val lat = state.latitudeInput.toDoubleOrNull() ?: return
-            val lng = state.longitudeInput.toDoubleOrNull() ?: return
+            val configGeneration = configWriteGate.currentGeneration()
             viewModelScope.launch {
-                locationRepository.updateConfig(
-                    lat = lat,
-                    lng = lng,
-                    simMode = if (state.routePlanStage == com.suseoaa.locationspoofer.data.model.RoutePlanStage.RUNNING) state.routeSimMode.name else "STILL",
-                    simBearing = state.simBearing,
-                    startTime = SpooferProvider.startTimestamp,
-                    routePoints = state.routePoints,
-                    isRouteMode = state.routePlanStage == com.suseoaa.locationspoofer.data.model.RoutePlanStage.RUNNING,
-                    appCoordinateSystems = state.appCoordinateSystems,
-                    wifiJson = state.collectedWifiJson,
-                    cellJson = state.collectedCellJson,
-                    bluetoothJson = state.collectedBluetoothJson,
-                    mockWifi = state.mockWifi,
-                    mockCell = state.mockCell,
-                    mockBluetooth = state.mockBluetooth,
-                    enableJitter = state.enableJitter
-                )
+                configWriteGate.runIfCurrent(configGeneration) {
+                    val state = _uiState.value
+                    val lat = state.latitudeInput.toDoubleOrNull() ?: return@runIfCurrent
+                    val lng = state.longitudeInput.toDoubleOrNull() ?: return@runIfCurrent
+                    locationRepository.updateConfig(
+                        lat = lat,
+                        lng = lng,
+                        simMode = if (state.routePlanStage == com.suseoaa.locationspoofer.data.model.RoutePlanStage.RUNNING) state.routeSimMode.name else "STILL",
+                        simBearing = state.simBearing,
+                        startTime = SpooferProvider.startTimestamp,
+                        routePoints = state.routePoints,
+                        isRouteMode = state.routePlanStage == com.suseoaa.locationspoofer.data.model.RoutePlanStage.RUNNING,
+                        appCoordinateSystems = state.appCoordinateSystems,
+                        wifiJson = state.collectedWifiJson,
+                        cellJson = state.collectedCellJson,
+                        bluetoothJson = state.collectedBluetoothJson,
+                        mockWifi = state.mockWifi && state.canMockWifi,
+                        mockCell = state.mockCell,
+                        mockBluetooth = state.mockBluetooth && state.canMockBluetooth,
+                        enableJitter = state.enableJitter
+                    )
+                }
             }
         }
     }
@@ -1771,17 +1877,25 @@ class MainViewModel(
         
         // If spoofing is active, update config
         if (_uiState.value.isSpoofingActive) {
+            val configGeneration = configWriteGate.currentGeneration()
             viewModelScope.launch {
-                locationRepository.updateConfig(
-                    SpooferProvider.latitude,
-                    SpooferProvider.longitude,
-                    SpooferProvider.simMode,
-                    SpooferProvider.simBearing,
-                    SpooferProvider.startTimestamp,
-                    if (SpooferProvider.isRouteMode) parseRoutePoints(SpooferProvider.routeJson) else emptyList(),
-                    SpooferProvider.isRouteMode,
-                    currentMap
-                )
+                configWriteGate.runIfCurrent(configGeneration) {
+                    val state = _uiState.value
+                    locationRepository.updateConfig(
+                        SpooferProvider.latitude,
+                        SpooferProvider.longitude,
+                        SpooferProvider.simMode,
+                        SpooferProvider.simBearing,
+                        SpooferProvider.startTimestamp,
+                        if (SpooferProvider.isRouteMode) parseRoutePoints(SpooferProvider.routeJson) else emptyList(),
+                        SpooferProvider.isRouteMode,
+                        currentMap,
+                        mockWifi = state.mockWifi && state.canMockWifi,
+                        mockCell = state.mockCell,
+                        mockBluetooth = state.mockBluetooth && state.canMockBluetooth,
+                        enableJitter = state.enableJitter
+                    )
+                }
             }
         }
     }
@@ -1793,17 +1907,25 @@ class MainViewModel(
         _uiState.update { it.copy(appCoordinateSystems = currentMap) }
 
         if (_uiState.value.isSpoofingActive) {
+            val configGeneration = configWriteGate.currentGeneration()
             viewModelScope.launch {
-                locationRepository.updateConfig(
-                    SpooferProvider.latitude,
-                    SpooferProvider.longitude,
-                    SpooferProvider.simMode,
-                    SpooferProvider.simBearing,
-                    SpooferProvider.startTimestamp,
-                    if (SpooferProvider.isRouteMode) parseRoutePoints(SpooferProvider.routeJson) else emptyList(),
-                    SpooferProvider.isRouteMode,
-                    currentMap
-                )
+                configWriteGate.runIfCurrent(configGeneration) {
+                    val state = _uiState.value
+                    locationRepository.updateConfig(
+                        SpooferProvider.latitude,
+                        SpooferProvider.longitude,
+                        SpooferProvider.simMode,
+                        SpooferProvider.simBearing,
+                        SpooferProvider.startTimestamp,
+                        if (SpooferProvider.isRouteMode) parseRoutePoints(SpooferProvider.routeJson) else emptyList(),
+                        SpooferProvider.isRouteMode,
+                        currentMap,
+                        mockWifi = state.mockWifi && state.canMockWifi,
+                        mockCell = state.mockCell,
+                        mockBluetooth = state.mockBluetooth && state.canMockBluetooth,
+                        enableJitter = state.enableJitter
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
@@ -114,7 +114,15 @@ class MainViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             val root = locationRepository.checkRootAccess()
 
-            if (settingsRepository.isSpoofingActive) {
+            if (settingsRepository.isSpoofingActive && settingsRepository.isRouteSpoofingActive) {
+                // Route progress is not persisted, so restoring it as the last fixed point is wrong.
+                // Explicitly end the stale route session instead.
+                settingsRepository.isSpoofingActive = false
+                settingsRepository.isRouteSpoofingActive = false
+                configWriteGate.runIfCurrent(initializationGeneration) {
+                    locationRepository.stopSpoofing(context)
+                }
+            } else if (settingsRepository.isSpoofingActive) {
                 val lastLat = settingsRepository.lastSpoofedLat.toDoubleOrNull()
                 val lastLng = settingsRepository.lastSpoofedLng.toDoubleOrNull()
                 if (lastLat != null && lastLng != null &&
@@ -147,13 +155,18 @@ class MainViewModel(
                     }
                     if (!generationCurrent || !repositoryStarted) {
                         settingsRepository.isSpoofingActive = false
+                        settingsRepository.isRouteSpoofingActive = false
                     }
                 } else {
                     settingsRepository.isSpoofingActive = false
+                    settingsRepository.isRouteSpoofingActive = false
                 }
-            } else if (SpoofingService.isRunning) {
-                configWriteGate.runIfCurrent(initializationGeneration) {
-                    locationRepository.stopSpoofing(context)
+            } else {
+                settingsRepository.isRouteSpoofingActive = false
+                if (SpoofingService.isRunning) {
+                    configWriteGate.runIfCurrent(initializationGeneration) {
+                        locationRepository.stopSpoofing(context)
+                    }
                 }
             }
 
@@ -944,6 +957,7 @@ class MainViewModel(
         }
         
         settingsRepository.isSpoofingActive = true
+        settingsRepository.isRouteSpoofingActive = false
         settingsRepository.lastSpoofedLat = lat.toString()
         settingsRepository.lastSpoofedLng = lng.toString()
         cancelLiveFixedLocationSync()
@@ -984,6 +998,7 @@ class MainViewModel(
             if (!wroteConfig || !repositoryStarted) {
                 if (configGeneration == configWriteGate.currentGeneration()) {
                     settingsRepository.isSpoofingActive = false
+                    settingsRepository.isRouteSpoofingActive = false
                     _uiState.update { it.copy(isSpoofingActive = false, isSavingConfig = false) }
                 }
                 return@launch
@@ -1003,6 +1018,7 @@ class MainViewModel(
     fun stopSpoofing() {
         val configGeneration = configWriteGate.beginNewGeneration()
         settingsRepository.isSpoofingActive = false
+        settingsRepository.isRouteSpoofingActive = false
         cancelLiveFixedLocationSync()
         locationSyncJob?.cancel()
         locationSyncJob = null
@@ -1252,6 +1268,7 @@ class MainViewModel(
         cancelLiveFixedLocationSync()
         val configGeneration = configWriteGate.beginNewGeneration()
         settingsRepository.isSpoofingActive = true
+        settingsRepository.isRouteSpoofingActive = true
         val startPoint = pointsToRun.first()
 
         _uiState.update {
@@ -1290,6 +1307,7 @@ class MainViewModel(
                 }
             } else if (configGeneration == configWriteGate.currentGeneration()) {
                 settingsRepository.isSpoofingActive = false
+                settingsRepository.isRouteSpoofingActive = false
                 _uiState.update {
                     it.copy(isSpoofingActive = false, routePlanStage = RoutePlanStage.READY)
                 }
@@ -1311,6 +1329,7 @@ class MainViewModel(
     fun stopRoutePlanning() {
         val configGeneration = configWriteGate.beginNewGeneration()
         settingsRepository.isSpoofingActive = false
+        settingsRepository.isRouteSpoofingActive = false
         locationSyncJob?.cancel()
         locationSyncJob = null
         autoRouteJob?.cancel()

--- a/app/src/main/java/com/suseoaa/locationspoofer/xposed/LocationHooker.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/xposed/LocationHooker.kt
@@ -37,7 +37,7 @@ abstract class XC_MethodHook {
 }
 
 object XposedHelpers {
-    lateinit var module: XposedModule
+    lateinit var module: XposedInterface
 
     fun findClass(className: String, classLoader: ClassLoader?): Class<*> {
         return Class.forName(className, false, classLoader ?: ClassLoader.getSystemClassLoader())
@@ -235,7 +235,12 @@ object XposedBridge {
     }
 }
 
-class LocationHooker : XposedModule() {
+class LocationHooker() : XposedModule() {
+    constructor(module: XposedInterface, param: XposedModuleInterface.ModuleLoadedParam) : this() {
+        XposedHelpers.module = module
+        onModuleLoaded(param)
+    }
+
     init {
         XposedHelpers.module = this
     }

--- a/app/src/main/java/com/suseoaa/locationspoofer/xposed/LocationHooker.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/xposed/LocationHooker.kt
@@ -37,7 +37,7 @@ abstract class XC_MethodHook {
 }
 
 object XposedHelpers {
-    lateinit var module: XposedInterface
+    lateinit var module: XposedModule
 
     fun findClass(className: String, classLoader: ClassLoader?): Class<*> {
         return Class.forName(className, false, classLoader ?: ClassLoader.getSystemClassLoader())
@@ -235,12 +235,7 @@ object XposedBridge {
     }
 }
 
-class LocationHooker() : XposedModule() {
-    constructor(module: XposedInterface, param: XposedModuleInterface.ModuleLoadedParam) : this() {
-        XposedHelpers.module = module
-        onModuleLoaded(param)
-    }
-
+class LocationHooker : XposedModule() {
     init {
         XposedHelpers.module = this
     }

--- a/app/src/test/java/com/suseoaa/locationspoofer/utils/ConfigWriteGateTest.kt
+++ b/app/src/test/java/com/suseoaa/locationspoofer/utils/ConfigWriteGateTest.kt
@@ -1,0 +1,61 @@
+package com.suseoaa.locationspoofer.utils
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ConfigWriteGateTest {
+    @Test
+    fun stopGenerationBecomesFinalWriterAfterBlockedOldWrite() = runBlocking {
+        val gate = ConfigWriteGate()
+        val oldGeneration = gate.currentGeneration()
+        val oldWriteStarted = CompletableDeferred<Unit>()
+        val releaseOldWrite = CompletableDeferred<Unit>()
+        val writes = mutableListOf<String>()
+
+        val oldWrite = async {
+            gate.runIfCurrent(oldGeneration) {
+                oldWriteStarted.complete(Unit)
+                releaseOldWrite.await()
+                writes += "active-old"
+            }
+        }
+        oldWriteStarted.await()
+
+        val stopGeneration = gate.beginNewGeneration()
+        val stopWrite = async {
+            gate.runIfCurrent(stopGeneration) {
+                writes += "inactive-stop"
+            }
+        }
+
+        releaseOldWrite.complete(Unit)
+
+        assertFalse(oldWrite.await())
+        assertTrue(stopWrite.await())
+        assertEquals(listOf("active-old", "inactive-stop"), writes)
+    }
+
+    @Test
+    fun queuedWriteFromObsoleteGenerationIsSkipped() = runBlocking {
+        val gate = ConfigWriteGate()
+        val obsoleteGeneration = gate.currentGeneration()
+        val currentGeneration = gate.beginNewGeneration()
+        val writes = mutableListOf<String>()
+
+        val obsoleteResult = gate.runIfCurrent(obsoleteGeneration) {
+            writes += "obsolete"
+        }
+        val currentResult = gate.runIfCurrent(currentGeneration) {
+            writes += "current"
+        }
+
+        assertFalse(obsoleteResult)
+        assertTrue(currentResult)
+        assertEquals(listOf("current"), writes)
+    }
+}

--- a/app/src/test/java/com/suseoaa/locationspoofer/utils/EnvironmentPayloadsTest.kt
+++ b/app/src/test/java/com/suseoaa/locationspoofer/utils/EnvironmentPayloadsTest.kt
@@ -1,0 +1,100 @@
+package com.suseoaa.locationspoofer.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EnvironmentPayloadsTest {
+    @Test
+    fun wifiObjectCountsNearbyAndConnectedData() {
+        val payload = """
+            {
+              "connectedWifi": {"bssid": "00:11:22:33:44:55"},
+              "nearbyWifi": [{"bssid": "66:77:88:99:aa:bb"}]
+            }
+        """.trimIndent()
+
+        val info = EnvironmentPayloads.inspectWifi(payload)
+
+        assertTrue(info.hasData)
+        assertEquals(1, info.nearbyCount)
+    }
+
+    @Test
+    fun connectedOnlyWifiObjectIsUsable() {
+        val info = EnvironmentPayloads.inspectWifi(
+            """{"connectedWifi":{"bssid":"00:11:22:33:44:55"},"nearbyWifi":[]}"""
+        )
+
+        assertTrue(info.hasData)
+        assertEquals(0, info.nearbyCount)
+    }
+
+    @Test
+    fun nearbyOnlyWifiObjectIsUsable() {
+        val info = EnvironmentPayloads.inspectWifi(
+            """{"connectedWifi":null,"nearbyWifi":[{"bssid":"00:11:22:33:44:55"}]}"""
+        )
+
+        assertTrue(info.hasData)
+        assertEquals(1, info.nearbyCount)
+    }
+
+    @Test
+    fun emptyWifiObjectIsNotUsable() {
+        val info = EnvironmentPayloads.inspectWifi(
+            """{"connectedWifi":null,"nearbyWifi":[]}"""
+        )
+
+        assertFalse(info.hasData)
+        assertEquals(0, info.nearbyCount)
+    }
+
+    @Test
+    fun wifiArrayIsNotAcceptedAsConfigObject() {
+        val info = EnvironmentPayloads.inspectWifi("[{}]")
+
+        assertFalse(info.hasData)
+        assertEquals(0, info.nearbyCount)
+    }
+
+    @Test
+    fun arrayPayloadRequiresAtLeastOneItem() {
+        assertTrue(EnvironmentPayloads.hasArrayItems("[{}]"))
+        assertFalse(EnvironmentPayloads.hasArrayItems("[]"))
+        assertFalse(EnvironmentPayloads.hasArrayItems("{}"))
+    }
+
+    @Test
+    fun explicitEmptySavedPayloadOverridesNonEmptyLocalCache() {
+        val merged = EnvironmentPayloads.merge(
+            localWifiJson = """{"nearbyWifi":[{}]}""",
+            localCellJson = "[{}]",
+            localBluetoothJson = "[{}]",
+            wifiJsonOverride = "[]",
+            cellJsonOverride = "[]",
+            bluetoothJsonOverride = "[]"
+        )
+
+        assertEquals("[]", merged.wifiJson)
+        assertEquals("[]", merged.cellJson)
+        assertEquals("[]", merged.bluetoothJson)
+    }
+
+    @Test
+    fun absentOverrideInheritsLocalCache() {
+        val merged = EnvironmentPayloads.merge(
+            localWifiJson = "local-wifi",
+            localCellJson = "local-cell",
+            localBluetoothJson = "local-bluetooth",
+            wifiJsonOverride = null,
+            cellJsonOverride = null,
+            bluetoothJsonOverride = null
+        )
+
+        assertEquals("local-wifi", merged.wifiJson)
+        assertEquals("local-cell", merged.cellJson)
+        assertEquals("local-bluetooth", merged.bluetoothJson)
+    }
+}

--- a/app/src/test/java/com/suseoaa/locationspoofer/utils/EnvironmentPayloadsTest.kt
+++ b/app/src/test/java/com/suseoaa/locationspoofer/utils/EnvironmentPayloadsTest.kt
@@ -67,19 +67,36 @@ class EnvironmentPayloadsTest {
     }
 
     @Test
-    fun explicitEmptySavedPayloadOverridesNonEmptyLocalCache() {
+    fun emptySavedPayloadInheritsNonEmptyLocalCache() {
         val merged = EnvironmentPayloads.merge(
             localWifiJson = """{"nearbyWifi":[{}]}""",
             localCellJson = "[{}]",
             localBluetoothJson = "[{}]",
-            wifiJsonOverride = "[]",
-            cellJsonOverride = "[]",
-            bluetoothJsonOverride = "[]"
+            wifiJsonOverride = EnvironmentPayloads.usableWifiOverride("[]"),
+            cellJsonOverride = EnvironmentPayloads.usableArrayOverride("[]"),
+            bluetoothJsonOverride = EnvironmentPayloads.usableArrayOverride("[]")
         )
 
-        assertEquals("[]", merged.wifiJson)
-        assertEquals("[]", merged.cellJson)
-        assertEquals("[]", merged.bluetoothJson)
+        assertEquals("""{"nearbyWifi":[{}]}""", merged.wifiJson)
+        assertEquals("[{}]", merged.cellJson)
+        assertEquals("[{}]", merged.bluetoothJson)
+    }
+
+    @Test
+    fun nonEmptySavedPayloadOverridesLocalCachePerChannel() {
+        val savedWifi = """{"connectedWifi":{"bssid":"00:11:22:33:44:55"},"nearbyWifi":[]}"""
+        val merged = EnvironmentPayloads.merge(
+            localWifiJson = "local-wifi",
+            localCellJson = "local-cell",
+            localBluetoothJson = "local-bluetooth",
+            wifiJsonOverride = EnvironmentPayloads.usableWifiOverride(savedWifi),
+            cellJsonOverride = EnvironmentPayloads.usableArrayOverride("[{}]"),
+            bluetoothJsonOverride = EnvironmentPayloads.usableArrayOverride("[{}]")
+        )
+
+        assertEquals(savedWifi, merged.wifiJson)
+        assertEquals("[{}]", merged.cellJson)
+        assertEquals("[{}]", merged.bluetoothJson)
     }
 
     @Test

--- a/app/src/test/java/com/suseoaa/locationspoofer/utils/RootManagerTest.kt
+++ b/app/src/test/java/com/suseoaa/locationspoofer/utils/RootManagerTest.kt
@@ -1,0 +1,20 @@
+package com.suseoaa.locationspoofer.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RootManagerTest {
+    @Test
+    fun successfulEmptyCommandReturnsSuccessMarker() {
+        assertEquals("SUCCESS", formatShellCommandResult(0, ""))
+    }
+
+    @Test
+    fun nonZeroCommandIncludesExitCodeAndOutput() {
+        val result = formatShellCommandResult(17, "permission denied")
+
+        assertTrue(result.startsWith("ERROR(exit=17):"))
+        assertTrue(result.contains("permission denied"))
+    }
+}

--- a/app/src/test/java/com/suseoaa/locationspoofer/utils/SavedLocationJsonCodecTest.kt
+++ b/app/src/test/java/com/suseoaa/locationspoofer/utils/SavedLocationJsonCodecTest.kt
@@ -1,0 +1,34 @@
+package com.suseoaa.locationspoofer.utils
+
+import com.suseoaa.locationspoofer.data.model.SavedLocation
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SavedLocationJsonCodecTest {
+    @Test
+    fun roundTripPreservesEnvironmentPayloads() {
+        val original = SavedLocation(
+            name = "saved",
+            lat = 39.9042,
+            lng = 116.4074,
+            wifiJson = "{\"connectedWifi\":null,\"nearbyWifi\":[{}]}",
+            cellJson = "[{\"mcc\":460}]",
+            bluetoothJson = "[{\"address\":\"00:11:22:33:44:55\"}]"
+        )
+
+        val decoded = SavedLocationJsonCodec.decode(SavedLocationJsonCodec.encode(listOf(original)))
+
+        assertEquals(listOf(original), decoded)
+    }
+
+    @Test
+    fun legacySavedLocationDefaultsMissingPayloads() {
+        val decoded = SavedLocationJsonCodec.decode(
+            "[{\"name\":\"legacy\",\"lat\":1.0,\"lng\":2.0}]"
+        ).single()
+
+        assertEquals("[]", decoded.wifiJson)
+        assertEquals("[]", decoded.cellJson)
+        assertEquals("[]", decoded.bluetoothJson)
+    }
+}


### PR DESCRIPTION
## Summary

- update the active fixed-location session immediately when a new search, custom, saved, map, or locally collected point is selected
- fetch or reuse matching Wi-Fi/cell/Bluetooth environment data before publishing the new config, and keep saved payloads aligned with their `mock_*` flags
- make rapid selections and stop/route transitions deterministic with a generation gate, transactional config publishing, and rollback on root-write failure
- persist the complete saved environment payload and keep coordinate formatting locale-stable
- add targeted tests for write ordering, saved payload decoding, environment fallback, and root command failures

## Details

Issue #24 asks to apply a new location without stopping an existing fixed-location spoofing session. A related comment also asks to switch saved locations directly.

All fixed-location selection sources now use the same path. While fixed spoofing is active and route playback is idle, the newest selection first resolves its environment payload, then updates both root config copies. Saved Wi-Fi data is decoded as the stored object shape (`connectedWifi` plus `nearbyWifi`) rather than as an array.

Config writes are staged in the destination directory and published as a two-copy transaction. A generation check and mutex ensure an older request cannot finish after a newer selection. Provider/service state, preferences, and UI state are committed only after the root write succeeds; a failure leaves the previous active point in place.

Route playback still owns its own session state. This PR does not change route semantics or add new hook features.

## Validation

- `:app:testDebugUnitTest :app:assembleDebug`
  - 15 tests passed, 0 failures/errors
- `git diff --check`
- Root_API30 / Android 11 / Magisk 26.4 / Vector 3043:
  - active A -> B fixed-location update
  - local Wi-Fi/LTE/BLE payload and saved-location replay
  - rapid A -> B newest-selection result
  - target-app Location, Wi-Fi, and cell reads
  - forced root denial verified config/preferences/UI rollback
  - stop left `active=false` with no stale rewrite
- OnePlus 9 Pro / LE2120 / Android 14 / Vector 3043:
  - active A -> B update without stop/start
  - uncached B entered the WiGLE/OpenCellID acquisition path; the test device had blank tokens, so the clients explicitly skipped remote requests rather than silently reusing stale data
  - saved A retained the Wi-Fi object, LTE, BLE, and all matching `mock_*` flags
  - rapid A -> B ended at B in both config copies and persisted coordinates
  - target probes read the new coordinates plus Wi-Fi/cell environment data
  - no current manager/target/system_server/lspd crash; the device's Vector DB, scope, packages, root policy, config files, and Bluetooth state were restored after testing

Notes:

- The local build uses a scratch signing key and dummy Maps API key; neither is included in this PR.
- Successful remote WiGLE/OpenCellID responses are not claimed because the validation devices had no tokens configured.
- Android 14 also exposed an existing BLE hook reflection compatibility issue while constructing a virtual `BluetoothDevice`. That hook code is outside this PR's diff and is not mixed into the issue #24 change.
- Existing project-wide lint failures remain outside this change; this PR does not add a lint baseline or workaround.

Addresses #24
