### PR TITLE
fix: 修复按 Back 键返回桌面时无法触发画中画的问题

### DIFF
--- a/app/src/main/java/com/suseoaa/locationspoofer/MainActivity.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.compose.LocalActivityResultRegistryOwner
@@ -68,6 +69,20 @@ class MainActivity : ComponentActivity() {
         }
 
         checkAndRequestPermissions()
+
+        // 拦截 Back 键：模拟定位开启时进入画中画，而非关闭 Activity
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (viewModel.uiState.value.isSpoofingActive) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        val params = android.app.PictureInPictureParams.Builder().build()
+                        enterPictureInPictureMode(params)
+                    }
+                } else {
+                    finish()
+                }
+            }
+        })
 
         setContent {
             CompositionLocalProvider(


### PR DESCRIPTION
- 新增 onBackPressedDispatcher 回调拦截 Back 键
- 模拟定位开启时按 Back 键 → 进入画中画，保持进程前台
- 未开启模拟定位时按 Back 键 → 正常结束 Activity