### PR TITLE
fix: 管理本地采集数据页面选择模式下按 Back 键退出选择模式而非关闭页面

### DIFF
--- a/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/ManageDataScreen.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/ManageDataScreen.kt
@@ -1,5 +1,6 @@
 package com.suseoaa.locationspoofer.ui.screen
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 
@@ -63,6 +64,12 @@ fun ManageDataScreen(
             val last = locations.last()
             controller.moveCamera(last.lat, last.lng, 15f)
         }
+    }
+
+    // 拦截返回键：如果处于选择模式，则先退出选择模式
+    BackHandler(enabled = isSelectionMode) {
+        isSelectionMode = false
+        selectedIds.clear()
     }
 
     Scaffold(


### PR DESCRIPTION
- 新增 BackHandler 拦截选择模式下的返回键
- 按 Back 键 → 退出选择模式并清空已选项
- 非选择模式下 Back 键行为不变