### PR TITLE
feat(favorite): 本地采集数据源星标支持取消收藏并完整显示长备注

### DIFF
--- a/app/src/main/java/com/suseoaa/locationspoofer/ui/components/LocalEnvironmentDataDialog.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/ui/components/LocalEnvironmentDataDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.suseoaa.locationspoofer.R
 import com.suseoaa.locationspoofer.data.db.CompleteLocation
+import com.suseoaa.locationspoofer.data.model.SavedLocation
 import com.suseoaa.locationspoofer.ui.theme.AccentBlue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -38,6 +39,7 @@ import java.util.Locale
 fun LocalEnvironmentDataDialog(
     dataList: List<CompleteLocation>,
     isLoading: Boolean,
+    savedLocations: List<SavedLocation>,
     onSelectPoint: (item: CompleteLocation) -> Unit,
     onFavorite: (item: CompleteLocation) -> Unit,
     onImportClick: () -> Unit,
@@ -45,6 +47,10 @@ fun LocalEnvironmentDataDialog(
 ) {
     var searchQuery by remember { mutableStateOf("") }
     val timeFormat = remember { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()) }
+
+    val favoritedCoords = remember(savedLocations) {
+        savedLocations.mapTo(HashSet()) { it.lat to it.lng }
+    }
 
     val filteredList = remember(dataList, searchQuery) {
         if (searchQuery.isBlank()) {
@@ -270,6 +276,7 @@ fun LocalEnvironmentDataDialog(
                             LocalDataItem(
                                 item = item,
                                 timeStr = timeFormat.format(Date(item.location.timestamp)),
+                                isFavorited = favoritedCoords.contains(item.location.lat to item.location.lng),
                                 onClick = {
                                     onSelectPoint(item)
                                     onDismiss()
@@ -327,6 +334,7 @@ fun LocalEnvironmentDataDialog(
 private fun LocalDataItem(
     item: CompleteLocation,
     timeStr: String,
+    isFavorited: Boolean,
     onClick: () -> Unit,
     onFavorite: () -> Unit
 ) {
@@ -370,8 +378,9 @@ private fun LocalDataItem(
                         fontSize = 15.5.sp,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onSurface,
-                        maxLines = 1,
-                        modifier = Modifier.weight(1f, fill = false)
+                        modifier = Modifier
+                            .weight(1f, fill = false)
+                            .padding(end = 8.dp)
                     )
                     Text(
                         text = timeStr,
@@ -430,8 +439,10 @@ private fun LocalDataItem(
 
             IconButton(onClick = onFavorite, modifier = Modifier.size(36.dp)) {
                 Icon(
-                    Icons.Rounded.StarOutline,
-                    contentDescription = stringResource(R.string.add_to_favorites),
+                    imageVector = if (isFavorited) Icons.Rounded.Star else Icons.Rounded.StarOutline,
+                    contentDescription = stringResource(
+                        if (isFavorited) R.string.remove_from_favorites else R.string.add_to_favorites
+                    ),
                     tint = AccentOrange,
                     modifier = Modifier.size(20.dp)
                 )

--- a/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/tabs/LocationTab.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/ui/screen/tabs/LocationTab.kt
@@ -65,6 +65,7 @@ import com.suseoaa.locationspoofer.ui.screen.*
 import com.suseoaa.locationspoofer.ui.screen.spoofing.SpoofingIntent
 import com.suseoaa.locationspoofer.ui.theme.AccentBlue
 import com.suseoaa.locationspoofer.ui.theme.noRippleClickable
+import com.suseoaa.locationspoofer.viewmodel.FavoriteToggleResult
 import com.suseoaa.locationspoofer.viewmodel.MainViewModel
 import com.suseoaa.locationspoofer.viewmodel.ManageDataViewModel
 import kotlinx.coroutines.launch
@@ -449,6 +450,7 @@ fun LocationTab(
         LocalEnvironmentDataDialog(
             dataList = manageDataUiState.dataList,
             isLoading = manageDataUiState.isLoading,
+            savedLocations = uiState.savedLocations,
             onSelectPoint = { item ->
                 val lat = item.location.lat
                 val lng = item.location.lng
@@ -472,16 +474,21 @@ fun LocationTab(
                 ).show()
             },
             onFavorite = { item ->
-                viewModel.saveCollectedLocationToFavorites(item.location.id) { name ->
-                    Toast.makeText(
-                        context,
-                        if (name != null) {
-                            context.getString(R.string.favorited_toast, name)
-                        } else {
-                            context.getString(R.string.favorite_failed)
-                        },
-                        Toast.LENGTH_SHORT
-                    ).show()
+                viewModel.toggleCollectedLocationFavorite(item.location.id) { result ->
+                    val message = when (result) {
+                        is FavoriteToggleResult.Added -> context.getString(
+                            R.string.favorited_toast,
+                            result.name
+                        )
+
+                        is FavoriteToggleResult.Removed -> context.getString(
+                            R.string.unfavorited_toast,
+                            result.name
+                        )
+
+                        FavoriteToggleResult.Failed -> context.getString(R.string.favorite_failed)
+                    }
+                    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
                 }
             },
             onImportClick = {

--- a/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/suseoaa/locationspoofer/viewmodel/MainViewModel.kt
@@ -49,6 +49,12 @@ import kotlinx.serialization.decodeFromString
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
+sealed interface FavoriteToggleResult {
+    data class Added(val name: String) : FavoriteToggleResult
+    data class Removed(val name: String) : FavoriteToggleResult
+    data object Failed : FavoriteToggleResult
+}
+
 class MainViewModel(
     private val locationRepository: LocationRepository,
     private val settingsRepository: SettingsRepository,
@@ -1651,6 +1657,45 @@ class MainViewModel(
             )
             _uiState.update { it.copy(savedLocations = settingsRepository.getSavedLocations()) }
             onResult(name)
+        }
+    }
+
+    fun toggleCollectedLocationFavorite(
+        locationId: Long,
+        onResult: (FavoriteToggleResult) -> Unit
+    ) {
+        viewModelScope.launch {
+            val record = withContext(Dispatchers.IO) {
+                environmentDao.getCompleteLocationById(locationId)
+            }
+            if (record == null) {
+                onResult(FavoriteToggleResult.Failed)
+                return@launch
+            }
+
+            val lat = record.location.lat
+            val lng = record.location.lng
+            // 收藏夹是独立快照，name 可能被改过，只能按经纬度关联
+            val existing = settingsRepository.getSavedLocations()
+                .firstOrNull { it.lat == lat && it.lng == lng }
+
+            if (existing != null) {
+                settingsRepository.removeSavedLocation(existing)
+                _uiState.update { it.copy(savedLocations = settingsRepository.getSavedLocations()) }
+                onResult(FavoriteToggleResult.Removed(existing.name))
+            } else {
+                val name = when {
+                    record.location.remark.isNotBlank() -> record.location.remark
+                    record.location.placeName.isNotBlank() -> record.location.placeName
+                    else -> String.format(Locale.US, "(%.5f, %.5f)", lat, lng)
+                }
+                val (wifiJson, cellJson, btJson) = locationToJson(listOf(record), lat, lng)
+                settingsRepository.addSavedLocation(
+                    SavedLocation(name, lat, lng, wifiJson, cellJson, btJson)
+                )
+                _uiState.update { it.copy(savedLocations = settingsRepository.getSavedLocations()) }
+                onResult(FavoriteToggleResult.Added(name))
+            }
         }
     }
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -491,6 +491,8 @@
     <string name="add_to_favorites">收藏</string>
     <string name="favorited_toast">已收藏“%1$s”</string>
     <string name="favorite_failed">收藏失败</string>
+    <string name="remove_from_favorites">取消收藏</string>
+    <string name="unfavorited_toast">已取消收藏“%1$s”</string>
     <string name="env_simulation_section">环境模拟</string>
     <string name="enable_slight_jitter_desc">加入自然的 GPS 漂移，让轨迹不那么机械</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -491,6 +491,8 @@ Error details: %s</string>
     <string name="add_to_favorites">Favorite</string>
     <string name="favorited_toast">Added \"%1$s\" to favorites</string>
     <string name="favorite_failed">Failed to add to favorites</string>
+    <string name="remove_from_favorites">Remove from favorites</string>
+    <string name="unfavorited_toast">Removed \"%1$s\" from favorites</string>
     <string name="env_simulation_section">Environment simulation</string>
     <string name="enable_slight_jitter_desc">Adds natural GPS drift so the track looks less mechanical</string>
 </resources>


### PR DESCRIPTION
## 📝 变更说明 / Description

Closes #56

issue #56 的主体功能已由维护者在 2d02772 中实现（两个页面可直接收藏、本地采集数据源页面美化、收藏夹不再重复显示经纬度）。本 PR 补齐该 issue 评论中剩余的反馈：

1. **长备注被截断（bug 修复）**：`LocalEnvironmentDataDialog` 的列表主标题原先写死 `maxLines = 1`，地名/备注超过约 7 个中文字就被裁掉。移除该限制，让过长的内容换行完整显示。
2. **星标实心/空心切换**：星标原先恒为 `StarOutline` 且只能添加。现在根据是否已收藏显示实心/空心，再次点击可取消收藏，并弹出对应提示。

实现说明：收藏夹是独立于采集数据的快照（保存了 wifi/cell/bt 的 JSON 副本），`name` 可能被用户改过，因此以经纬度作为采集点与收藏点的唯一关联；取消收藏复用 `removeSavedLocation` 的按经纬度删除口径。新增 `MainViewModel.toggleCollectedLocationFavorite` 与 `FavoriteToggleResult (Added/Removed/Failed)`。

### 真机效果 / Screenshot

![本地采集数据源星标与长备注](https://raw.githubusercontent.com/servant1228/LocationSpoofer/assets/issue-56/issue-56-favorite-toggle.jpg)

---

## 🔍 变更类型 / Type of Change

- [x] 🐛 Bug 修复 / Bug fix (non-breaking change which fixes an issue)
- [x] ✨ 新增功能 / New feature (non-breaking change which adds functionality)
- [ ] ♻️ 代码重构 / Refactoring / Code cleanup (no functional changes)
- [ ] ⚡ 性能优化 / Performance improvement
- [ ] 📝 文档更新 / Documentation update
- [ ] 🔧 构建配置与工程维护 / Build / CI / Tooling configuration

---

## 🧪 测试与验证 / Testing & Verification

- [x] 已在实体 Root 设备上完成测试 / Tested on physical rooted device
  - 设备型号 / Device Model: 一加 ACE6T
  - 系统版本 / Android Version: Android 16
  - Root 方案与 LSPosed 版本 / Root Manager & LSPosed Version: 官方 KernelSU + 官方 LSPosed 2.1.1 (7790)
- [x] 编译通过 / Verified build succeeds (`./gradlew assembleDebug`)
- [x] 模块启用后目标应用功能正常 / Verified target applications function properly with the module active —— 本次仅改主 App 交互，未触碰 Hook 层
- [x] 检查 LSPosed 模块日志与 Logcat 无异常抛出 / Checked LSPosed module logs and logcat for any unexpected exceptions

---

## 📋 自检清单 / Checklist

- [x] 代码遵循项目的架构规范与 Kotlin 编码风格 / My code adheres to the project's coding style and architecture guidelines.
- [x] 已对提交的代码进行了仔细自审 / I have performed a self-review of my own code.
- [x] 对复杂或非显而易见的逻辑添加了必要的注释 / I have commented my code where necessary.
- [x] 编译过程中没有产生新的警告或错误 / My changes generate no new warnings or build errors.
- [x] 如涉及功能变更，已同步更新相关文档（如 `README.md` / `README_EN.md`）/ I have updated documentation if applicable. —— 本次为既有功能的小幅交互调整，README 无对应说明，无需更新
